### PR TITLE
Fix missing parenthesis

### DIFF
--- a/src/pages/guide/best-practices.md
+++ b/src/pages/guide/best-practices.md
@@ -19,7 +19,7 @@ We recommend using the following best practices when developing themes:
 
     See the [Layout chapter of this Guide](layouts/index.md) for more information on working with layouts.
 
-1. Reuse the markup and design patterns from the default application files by referencing the existing `.phtml` templates ([templates hints can help](themes/debug.md#templates) or copy-pasting HTML markup to your custom templates.
+1. Reuse the markup and design patterns from the default application files by referencing the existing `.phtml` templates ([templates hints can help](themes/debug.md#templates)) or copy-pasting HTML markup to your custom templates.
 1. Use `<theme_dir>/etc/view.xml` to change image types or sizes, or add your own types. See [Configure images properties](themes/configure.md) for details. Use this file to also [customize the product gallery widget](https://devdocs.magento.com/guides/v2.4/javascript-dev-guide/widgets/widget_gallery.html).
 1. If you need to change the wording in the user interface, [add custom CSV dictionary files](translations/dictionary.md) instead of overriding `.phtml` templates.
 1. Use [the CSS critical path](css/critical-path.md) to render the page much faster.


### PR DESCRIPTION
Add missing closing parenthesis: "(templates hints can help)" instead of "(templates hints can help".

## Purpose of this pull request

<!--- Describe your changes in detail -->

This pull request (PR) adds a closing parenthesis after "(templates hints can help" to fix the syntax and improve readibility. 

## Affected pages

<!-- REQUIRED List the pages/URLs on the [Adobe devsite](https://developer.adobe.com/. Not needed for large numbers of files. -->

-  [Theme development best practices](https://developer.adobe.com/commerce/frontend-core/guide/best-practices/)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`
`beta` is the default branch. Merged pull requests to `main` go live on the site automatically.
See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-  [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-  [x] My changes follow the code style of this project.
-  [x] I have read the **CONTRIBUTING** document.
-  [ ] All new and existing tests passed.
