### PR TITLE
Bump aio-theme to 4.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AdobeDocs/commerce-frontend-core"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "4.3.0",
+    "@adobe/gatsby-theme-aio": "4.4.2",
     "gatsby": "4.19.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,19 +33,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/gatsby-theme-aio@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@adobe/gatsby-theme-aio@npm:4.3.0"
+"@adobe/gatsby-theme-aio@npm:4.4.2":
+  version: 4.4.2
+  resolution: "@adobe/gatsby-theme-aio@npm:4.4.2"
   dependencies:
     "@adobe/focus-ring-polyfill": ^0.1.5
     "@adobe/gatsby-source-github-file-contributors": ^0.3.1
     "@adobe/prism-adobe": ^1.0.3
-    "@emotion/react": ^11.4.1
-    "@loadable/component": ^5.14.1
-    "@mdx-js/mdx": ^1.6.22
-    "@mdx-js/react": ^1.6.22
+    "@emotion/react": ^11.9.3
+    "@loadable/component": ^5.15.2
+    "@mdx-js/mdx": 1.6.22
+    "@mdx-js/react": 1.6.22
     "@spectrum-css/accordion": 3.0.24
-    "@spectrum-css/actionbutton": 2.0.0
+    "@spectrum-css/actionbutton": 2.1.0
     "@spectrum-css/actiongroup": ^2.0.0
     "@spectrum-css/assetlist": 3.0.24
     "@spectrum-css/badge": ^1.0.20
@@ -53,20 +53,20 @@ __metadata:
     "@spectrum-css/button": 6.0.13
     "@spectrum-css/card": 5.0.0
     "@spectrum-css/checkbox": 3.1.3
-    "@spectrum-css/dialog": 6.0.14
+    "@spectrum-css/dialog": 6.0.15
     "@spectrum-css/divider": 1.0.27
     "@spectrum-css/icon": 3.0.23
     "@spectrum-css/inlinealert": 4.0.13
     "@spectrum-css/link": 3.1.23
     "@spectrum-css/menu": 4.0.4
     "@spectrum-css/modal": 3.0.23
-    "@spectrum-css/picker": 1.2.10
-    "@spectrum-css/popover": 5.0.17
+    "@spectrum-css/picker": 1.2.12
+    "@spectrum-css/popover": 5.0.18
     "@spectrum-css/progresscircle": 1.0.23
     "@spectrum-css/search": 4.2.12
     "@spectrum-css/sidenav": 3.0.24
     "@spectrum-css/table": 4.0.19
-    "@spectrum-css/tabs": 3.2.17
+    "@spectrum-css/tabs": 3.2.19
     "@spectrum-css/textfield": 3.2.4
     "@spectrum-css/tooltip": 3.1.18
     "@spectrum-css/typography": 4.0.20
@@ -74,54 +74,54 @@ __metadata:
     "@spectrum-css/vars": 8.0.0
     "@spectrum-css/well": 3.0.22
     algolia-html-extractor: ^0.0.1
-    algoliasearch: 4.10.4
+    algoliasearch: 4.14.2
     await-exec: ^0.1.2
     builtin-status-codes: ^3.0.0
-    classnames: ^2.2.6
-    core-js: ^3.16.3
-    gatsby-plugin-algolia: ^0.22.1
-    gatsby-plugin-emotion: ^7.13.0
-    gatsby-plugin-layout: ^3.13.0
-    gatsby-plugin-mdx: ^3.13.0
+    classnames: ^2.3.1
+    core-js: ^3.24.0
+    gatsby-plugin-algolia: ^0.26.0
+    gatsby-plugin-emotion: ^7.19.0
+    gatsby-plugin-layout: ^3.19.0
+    gatsby-plugin-mdx: ^3.19.0
     gatsby-plugin-mdx-embed: ^1.0.0
-    gatsby-plugin-preact: ^6.13.0
-    gatsby-plugin-react-helmet: ^5.13.0
-    gatsby-plugin-sharp: ^4.13.0
-    gatsby-remark-copy-linked-files: ^5.13.0
-    gatsby-remark-images-remote: ^1.1.0
-    gatsby-source-filesystem: ^4.13.0
-    gatsby-transformer-remark: ^5.1.1
-    gatsby-transformer-sharp: ^4.13.0
+    gatsby-plugin-preact: ^6.19.0
+    gatsby-plugin-react-helmet: ^5.19.0
+    gatsby-plugin-sharp: ^4.19.0
+    gatsby-remark-autolink-headers: ^5.19.0
+    gatsby-remark-copy-linked-files: ^5.19.0
+    gatsby-remark-images: ^6.19.0
+    gatsby-source-filesystem: ^4.19.0
+    gatsby-transformer-remark: ^5.19.0
+    gatsby-transformer-sharp: ^4.19.0
     https-browserify: ^1.0.0
     lmdb-store: ^1.6.14
-    mdx-embed: ^0.0.19
-    mobx: ^6.3.2
+    mdx-embed: ^1.0.0
+    mobx: ^6.6.1
     os-browserify: ^0.3.0
     path-browserify: ^1.0.1
-    penpal: ^6.1.0
-    postcss: ^8.4.12
-    preact: ^10.5.12
-    preact-render-to-string: ^5.1.16
-    prism-react-renderer: 1.2.1
-    prop-types: ^15.7.2
+    penpal: ^6.2.2
+    postcss: ^8.4.14
+    preact: ^10.10.0
+    preact-render-to-string: ^5.2.1
+    prism-react-renderer: 1.3.5
+    prop-types: ^15.8.1
     react-helmet: ^6.1.0
-    react-id-generator: ^3.0.1
-    redoc: 2.0.0-rc.56
-    redoc-cli: ^0.13.0
-    rehype-slug: ^4.0.1
-    sharp: ^0.29.0
-    stream-http: ^3.1.1
-    styled-components: ^5.3.1
-    swiper: ^7.0.6
+    react-id-generator: ^3.0.2
+    redoc: 2.0.0-rc.73
+    redoc-cli: ^0.13.16
+    sharp: ^0.30.7
+    stream-http: ^3.2.0
+    styled-components: ^5.3.5
+    swiper: ^8.3.2
     to-arraybuffer: ^1.0.1
     tty-browserify: ^0.0.1
-    unist-util-select: 2.0.0
+    unist-util-select: 2.0.2
     uuid: ^8.3.2
   peerDependencies:
-    gatsby: ^4.12.1
-    react: ^17.0.0
-    react-dom: ^17.0.0
-  checksum: 54c29796c3c96c7424cec1f2a4c3103ff1e75eb22be618a799bd3da4d375e8d41c0476745f213bbfa243383e120fd66bc6137a039036d330424cf1e65f59877f
+    gatsby: ^4.19.2
+    react: ^17.0.2
+    react-dom: ^17.0.2
+  checksum: baaf309ff286fb49db18ffe4e1f32968db35fc3439942bfae90154759910c2bae891a8fd89dc36b3047790865e44600c1c2d323bcbcd91a364fb89072be2fb94
   languageName: node
   linkType: hard
 
@@ -129,15 +129,6 @@ __metadata:
   version: 1.0.3
   resolution: "@adobe/prism-adobe@npm:1.0.3"
   checksum: d9f9fc96ef2f718c5328fd9f4cfbba69d7ea11f1e38eeb599c8a7c5221597e507aa6ade526284c86f6310f3737851c304078c613491c1db23b65be6f7b9bef9a
-  languageName: node
-  linkType: hard
-
-"@algolia/cache-browser-local-storage@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/cache-browser-local-storage@npm:4.10.4"
-  dependencies:
-    "@algolia/cache-common": 4.10.4
-  checksum: df897a7e96b1428b74aab89007b05596dabc4d68d93f0d3d2f09eaa374b8789952483a70c6bad8d98e876c93506c05443b5f05804670fbf6aa853ddaae209dc3
   languageName: node
   linkType: hard
 
@@ -150,10 +141,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/cache-common@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/cache-common@npm:4.10.4"
-  checksum: 1ddd7fbd96888dbfa404e6b8cac88be245b8adb29b7b0947db420abd34c82972a81519359c2d9a9e848bf74f85ee9e17655af0f475500d769053239dce62323d
+"@algolia/cache-browser-local-storage@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/cache-browser-local-storage@npm:4.14.2"
+  dependencies:
+    "@algolia/cache-common": 4.14.2
+  checksum: e7d5f43ff01df5f21a2b5304b5d8f8ae25f2c6093e83e79556cb78ae07f342111ba77eba633b837b5b74a17293ea6a208acb1ade71782baafa9c2da7d58ee45c
   languageName: node
   linkType: hard
 
@@ -164,12 +157,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/cache-in-memory@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/cache-in-memory@npm:4.10.4"
-  dependencies:
-    "@algolia/cache-common": 4.10.4
-  checksum: cefb3bda55ef77ce80f97aa3b74830a4595cf25af7c8ceb5daf1a06d67d23e46ac47b4a1a5302d4dc720041e2f29af7a534704c75d15e6aab1ccc8bdb9f7c11a
+"@algolia/cache-common@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/cache-common@npm:4.14.2"
+  checksum: 4fd04c714aee19f6eaaac4ae7e00e914a44473af9a84cf3c4260e436c6ea20f5590e05e9006d963372d84ce57268776811fcb929d79e0415b59d74779bd31ee7
   languageName: node
   linkType: hard
 
@@ -182,14 +173,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/client-account@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/client-account@npm:4.10.4"
+"@algolia/cache-in-memory@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/cache-in-memory@npm:4.14.2"
   dependencies:
-    "@algolia/client-common": 4.10.4
-    "@algolia/client-search": 4.10.4
-    "@algolia/transporter": 4.10.4
-  checksum: 3122f6e1a140b8306d525d9eadcadc7bbde16c03d9f74fea1be53e2b17b9da9643293a7b36cbe7b07f4881a6a1bded9db4c8d84f1773223651abf49c694e873a
+    "@algolia/cache-common": 4.14.2
+  checksum: d6981f812a368a38db21e52c98ec81a5c0eda5d896377f7bdcc04a0be1673ac9e184836d7973065fab84dc947a63fe959586468fc14b9a87e32f916959df6222
   languageName: node
   linkType: hard
 
@@ -204,15 +193,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/client-analytics@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/client-analytics@npm:4.10.4"
+"@algolia/client-account@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/client-account@npm:4.14.2"
   dependencies:
-    "@algolia/client-common": 4.10.4
-    "@algolia/client-search": 4.10.4
-    "@algolia/requester-common": 4.10.4
-    "@algolia/transporter": 4.10.4
-  checksum: e1af4d5e1e968883e97298af3cf72e1723dd12995b0324dac6c47cbbcc9a40fd300bbba4ea8c6a954055d5098e1245e0beb621aace005e9855af255d467f72ea
+    "@algolia/client-common": 4.14.2
+    "@algolia/client-search": 4.14.2
+    "@algolia/transporter": 4.14.2
+  checksum: 2e9eed5a4b8434775af87899bda8140d51eb2dd0cf08fc49370a4dc9541c220db9b241976dad14ae5d07a25f7ddafd9759a2eb462788f21a20f14e04968f98a4
   languageName: node
   linkType: hard
 
@@ -228,13 +216,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/client-common@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/client-common@npm:4.10.4"
+"@algolia/client-analytics@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/client-analytics@npm:4.14.2"
   dependencies:
-    "@algolia/requester-common": 4.10.4
-    "@algolia/transporter": 4.10.4
-  checksum: 27b1ea28b4f29f1b50efbbb90a8fe48e1e200a4886dc41accc03010165746386ebfb90e9e36f4a3b3d47dfd944f2dbade6a900fc3910b859b90a1d69e32d0c06
+    "@algolia/client-common": 4.14.2
+    "@algolia/client-search": 4.14.2
+    "@algolia/requester-common": 4.14.2
+    "@algolia/transporter": 4.14.2
+  checksum: 61874e026c9d08dd628da443b5b34d1a3bb707a0283e727d94ee6d61057631039c5cf6303e6234cc6fbe84ff71c2758f952b664277715ca5761819aec73e7aad
   languageName: node
   linkType: hard
 
@@ -248,14 +238,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/client-personalization@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/client-personalization@npm:4.10.4"
+"@algolia/client-common@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/client-common@npm:4.14.2"
   dependencies:
-    "@algolia/client-common": 4.10.4
-    "@algolia/requester-common": 4.10.4
-    "@algolia/transporter": 4.10.4
-  checksum: 1dde4dfe33366e729cebc06dacec162daed36564299ed8467a4fe42fe58a71a7396d769bef18388574ea5b0ae25ac3f837db6e8fbcec1f9ed2a3991b5016dbbf
+    "@algolia/requester-common": 4.14.2
+    "@algolia/transporter": 4.14.2
+  checksum: da2be279ac51e1b43c02c6d2bbf0d9cc8b1cb3250ad10a803fca609bcfb8164a8adc21281b599fd8aa322c04deea77d2f07adcae1a363952559472e781e26c71
   languageName: node
   linkType: hard
 
@@ -270,14 +259,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/client-search@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/client-search@npm:4.10.4"
+"@algolia/client-personalization@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/client-personalization@npm:4.14.2"
   dependencies:
-    "@algolia/client-common": 4.10.4
-    "@algolia/requester-common": 4.10.4
-    "@algolia/transporter": 4.10.4
-  checksum: 40a3f34b5ff871ce118d85b977d64f434ee04e8952f79bf48c21566fe92969b2795ce4b4190cab4bd460645dbac72722ea77a3db264c939fa9226203608b6d99
+    "@algolia/client-common": 4.14.2
+    "@algolia/requester-common": 4.14.2
+    "@algolia/transporter": 4.14.2
+  checksum: 0dd25c84a40fe9853d14fadc3c8893e84bee370b5a3eb6730afe816afe1f92b970096d2dfb68073f606fa074fdeb66c3a73811d9a9a9774af5311f34d939fd72
   languageName: node
   linkType: hard
 
@@ -292,10 +281,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/logger-common@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/logger-common@npm:4.10.4"
-  checksum: 1758790597dee035366428b7f3ae399d51d257a584e685b07bb2b3a97ae9a2250a6fdc241cd3956d225f2050b53bdfc31afb54ca11f83b91953cd0ea910054fc
+"@algolia/client-search@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/client-search@npm:4.14.2"
+  dependencies:
+    "@algolia/client-common": 4.14.2
+    "@algolia/requester-common": 4.14.2
+    "@algolia/transporter": 4.14.2
+  checksum: 2695bc9e8c98badb601b915dbb075dd92996af350b0e4915a7a3b7825bd45f20815534debcfcb51bb7f682ba5d09f3c41918edb36e0a7f7bb154d3b205825f65
   languageName: node
   linkType: hard
 
@@ -306,12 +299,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/logger-console@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/logger-console@npm:4.10.4"
-  dependencies:
-    "@algolia/logger-common": 4.10.4
-  checksum: b7ebe9f8c656a360110ff19bc4f0a92600feacb470d169441a559010bda65489b8b91ecfd9610ddc0b53d7b06ffd802a80b5fe0a81decef817d9e2226df9dd18
+"@algolia/logger-common@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/logger-common@npm:4.14.2"
+  checksum: a4000a98831d64c8d826ccece9f5f3a77bc000d93d74a7c6b51f186d3dfd96c0bb00934f70c69da8f3c4dfb9f30ce55ab59aca9ba79c3cc3e924597838a94429
   languageName: node
   linkType: hard
 
@@ -324,12 +315,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/requester-browser-xhr@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/requester-browser-xhr@npm:4.10.4"
+"@algolia/logger-console@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/logger-console@npm:4.14.2"
   dependencies:
-    "@algolia/requester-common": 4.10.4
-  checksum: dd8ac79299154de6b183517d518bbd8160a0f61122d47339082ee3d1f637d1d33aae0db2bcab6e86bd534e6eeddcb42f670aef1217cdbdd63dd95ab0ad2e6e3d
+    "@algolia/logger-common": 4.14.2
+  checksum: 96c6209c7ef72cbc170b180f5b84c6523a5b6f4dea978c982577d2417eb19eb9c9ea3bc73089ced692a05bec141d66fd6d5401458d0aa162dbcace5017dbd127
   languageName: node
   linkType: hard
 
@@ -342,10 +333,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/requester-common@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/requester-common@npm:4.10.4"
-  checksum: 188dbe8bcc7721aa9b19d42011624b1b9f4207744fe17d70bb66610afcb8658beb5eb79653b477dd61bcc76963cf0e3167b5758201641ad691c67f1c65efbd1a
+"@algolia/requester-browser-xhr@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/requester-browser-xhr@npm:4.14.2"
+  dependencies:
+    "@algolia/requester-common": 4.14.2
+  checksum: 7d8666e21cd0d15dc2e25f6917464c2f98cf73e0d2fced94cc6a3c4e97a990b8b93d9531bbf6f3b1ff2342b9ce9760d1dcb64dbbf61a5f2c31fe4f42541deef2
   languageName: node
   linkType: hard
 
@@ -356,12 +349,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/requester-node-http@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/requester-node-http@npm:4.10.4"
-  dependencies:
-    "@algolia/requester-common": 4.10.4
-  checksum: 0f96bf0cde227e54f6f56611c0c95cc4c43ec5d3917d4679cbf19ceddf41035c6571891c9b964e26f227edc68ab42f1a312031dd5d0d9d614efd2d22ce4a9f17
+"@algolia/requester-common@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/requester-common@npm:4.14.2"
+  checksum: 7de4148a55db56fe2bf18c1359cccbc2f41031fe2bfbc945d75f143b854638c51e7ec2ef9c6dc69b38d5edb87cd096ce5d7087680da32825562db79026ea39cc
   languageName: node
   linkType: hard
 
@@ -374,14 +365,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/transporter@npm:4.10.4":
-  version: 4.10.4
-  resolution: "@algolia/transporter@npm:4.10.4"
+"@algolia/requester-node-http@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/requester-node-http@npm:4.14.2"
   dependencies:
-    "@algolia/cache-common": 4.10.4
-    "@algolia/logger-common": 4.10.4
-    "@algolia/requester-common": 4.10.4
-  checksum: 0cb618fb01be90201403338a50b2d404ae7535f8ec6ae1deb1e61d773d873a82d2833acc7a9a512a75c685464051d6b178a6434b0acffa34e3e904090298293e
+    "@algolia/requester-common": 4.14.2
+  checksum: 5f5fe8b040f73bd95c6bdb5b97396e078b629b2b4cd93fea671d545be375c79501c65296c34824f0ff8368b5b51edc7a6ad9e694b04223c1416dcda869c6f566
   languageName: node
   linkType: hard
 
@@ -393,6 +382,17 @@ __metadata:
     "@algolia/logger-common": 4.14.1
     "@algolia/requester-common": 4.14.1
   checksum: 162524cf71d50d9aeb60f8759e4e3bc959032cab7fdadb223971deb338df8eb89afc83e0fc8616b6415152a56360e22baf34fa608fe4169bd328e7cf091dc78b
+  languageName: node
+  linkType: hard
+
+"@algolia/transporter@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/transporter@npm:4.14.2"
+  dependencies:
+    "@algolia/cache-common": 4.14.2
+    "@algolia/logger-common": 4.14.2
+    "@algolia/requester-common": 4.14.2
+  checksum: 72c72013f3edb4d4484e7a43fb3c2555646ab04f422249514ed0309e20f41f5563f4c4dcf5623ca64c293624ecc74f87acaf2d9820e8c829cb5de067bdfe0257
   languageName: node
   linkType: hard
 
@@ -665,7 +665,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.0.0, @babel/helper-module-imports@npm:^7.0.0-beta.49, @babel/helper-module-imports@npm:^7.12.13, @babel/helper-module-imports@npm:^7.16.0, @babel/helper-module-imports@npm:^7.18.6":
+"@babel/helper-module-imports@npm:^7.0.0, @babel/helper-module-imports@npm:^7.0.0-beta.49, @babel/helper-module-imports@npm:^7.12.13, @babel/helper-module-imports@npm:^7.16.0, @babel/helper-module-imports@npm:^7.16.7, @babel/helper-module-imports@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-module-imports@npm:7.18.6"
   dependencies:
@@ -1149,7 +1149,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.0.0, @babel/plugin-syntax-jsx@npm:^7.12.13, @babel/plugin-syntax-jsx@npm:^7.18.6, @babel/plugin-syntax-jsx@npm:^7.2.0":
+"@babel/plugin-syntax-jsx@npm:^7.0.0, @babel/plugin-syntax-jsx@npm:^7.12.13, @babel/plugin-syntax-jsx@npm:^7.17.12, @babel/plugin-syntax-jsx@npm:^7.18.6, @babel/plugin-syntax-jsx@npm:^7.2.0":
   version: 7.18.6
   resolution: "@babel/plugin-syntax-jsx@npm:7.18.6"
   dependencies:
@@ -1868,7 +1868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.14.0, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.7, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.7, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.18.9
   resolution: "@babel/runtime@npm:7.18.9"
   dependencies:
@@ -1936,7 +1936,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/babel-plugin@npm:^11.2.0, @emotion/babel-plugin@npm:^11.7.1":
+"@emotion/babel-plugin@npm:^11.10.0":
+  version: 11.10.0
+  resolution: "@emotion/babel-plugin@npm:11.10.0"
+  dependencies:
+    "@babel/helper-module-imports": ^7.16.7
+    "@babel/plugin-syntax-jsx": ^7.17.12
+    "@babel/runtime": ^7.18.3
+    "@emotion/hash": ^0.9.0
+    "@emotion/memoize": ^0.8.0
+    "@emotion/serialize": ^1.1.0
+    babel-plugin-macros: ^3.1.0
+    convert-source-map: ^1.5.0
+    escape-string-regexp: ^4.0.0
+    find-root: ^1.1.0
+    source-map: ^0.5.7
+    stylis: 4.0.13
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 7f1c615e5e559fd037eab8d08b842cd6c089543f9c8829d22d097f69c5436298ff4fa9e1a2117892ce26a60abc1f57641dd9ccb011096b2e34c5588bf994addc
+  languageName: node
+  linkType: hard
+
+"@emotion/babel-plugin@npm:^11.2.0":
   version: 11.9.2
   resolution: "@emotion/babel-plugin@npm:11.9.2"
   dependencies:
@@ -1972,16 +1994,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:^11.9.3":
-  version: 11.9.3
-  resolution: "@emotion/cache@npm:11.9.3"
+"@emotion/cache@npm:^11.10.0":
+  version: 11.10.1
+  resolution: "@emotion/cache@npm:11.10.1"
   dependencies:
-    "@emotion/memoize": ^0.7.4
-    "@emotion/sheet": ^1.1.1
-    "@emotion/utils": ^1.0.0
-    "@emotion/weak-memoize": ^0.2.5
+    "@emotion/memoize": ^0.8.0
+    "@emotion/sheet": ^1.2.0
+    "@emotion/utils": ^1.2.0
+    "@emotion/weak-memoize": ^0.3.0
     stylis: 4.0.13
-  checksum: 6e0aab2fa5b9b6b0b9bf66b5328ed44265c23ced16b46c13d2602c3497fabd95299f6cf2c87cbc02b630452aa3cff599c194c538125d744aa135824129698ccc
+  checksum: 950203c5a447c107a189042178fdf43b2e699f579e2d7cd9f39cb99ee2b1f20d84bb1ed653d2737a1adb79756c1f747783875ee76ccb547357f5aa9cd5ce63ee
   languageName: node
   linkType: hard
 
@@ -1989,6 +2011,13 @@ __metadata:
   version: 0.8.0
   resolution: "@emotion/hash@npm:0.8.0"
   checksum: 4b35d88a97e67275c1d990c96d3b0450451d089d1508619488fc0acb882cb1ac91e93246d471346ebd1b5402215941ef4162efe5b51534859b39d8b3a0e3ffaa
+  languageName: node
+  linkType: hard
+
+"@emotion/hash@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@emotion/hash@npm:0.9.0"
+  checksum: b63428f7c8186607acdca5d003700cecf0ded519d0b5c5cc3b3154eafcad6ff433f8361bd2bac8882715b557e6f06945694aeb6ba8b25c6095d7a88570e2e0bb
   languageName: node
   linkType: hard
 
@@ -2008,16 +2037,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/react@npm:^11.4.1":
-  version: 11.9.3
-  resolution: "@emotion/react@npm:11.9.3"
+"@emotion/memoize@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@emotion/memoize@npm:0.8.0"
+  checksum: c87bb110b829edd8e1c13b90a6bc37cebc39af29c7599a1e66a48e06f9bec43e8e53495ba86278cc52e7589549492c8dfdc81d19f4fdec0cee6ba13d2ad2c928
+  languageName: node
+  linkType: hard
+
+"@emotion/react@npm:^11.9.3":
+  version: 11.10.0
+  resolution: "@emotion/react@npm:11.10.0"
   dependencies:
-    "@babel/runtime": ^7.13.10
-    "@emotion/babel-plugin": ^11.7.1
-    "@emotion/cache": ^11.9.3
-    "@emotion/serialize": ^1.0.4
-    "@emotion/utils": ^1.1.0
-    "@emotion/weak-memoize": ^0.2.5
+    "@babel/runtime": ^7.18.3
+    "@emotion/babel-plugin": ^11.10.0
+    "@emotion/cache": ^11.10.0
+    "@emotion/serialize": ^1.1.0
+    "@emotion/utils": ^1.2.0
+    "@emotion/weak-memoize": ^0.3.0
     hoist-non-react-statics: ^3.3.1
   peerDependencies:
     "@babel/core": ^7.0.0
@@ -2027,11 +2063,11 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 19bc7205e85e87cadebbe5a926d45103b836af70ab6972ea4c333c8dd01b463fc9646d4e4097a36f145a05dd4bc388739667437b990f8cf7f7f925f9610d1aa8
+  checksum: 6d692e43ff53fd3b87d4a000a9aec2ef080d66a0ebb7d0b9529c46d1e6bc1ac8a27c7dd74c27a8274ec1df1e3c960b78c035fca5d8a901a48eda445c6163b33b
   languageName: node
   linkType: hard
 
-"@emotion/serialize@npm:^1.0.2, @emotion/serialize@npm:^1.0.4":
+"@emotion/serialize@npm:^1.0.2":
   version: 1.0.4
   resolution: "@emotion/serialize@npm:1.0.4"
   dependencies:
@@ -2044,10 +2080,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/sheet@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@emotion/sheet@npm:1.1.1"
-  checksum: b916ac665735ef6dfda26b09f2d3493789d432d649733db9da18c4db0115e7fdadeb8d45f6490320248916bb13d978bba74c914b711ac96f659b76a5e52d5cd2
+"@emotion/serialize@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@emotion/serialize@npm:1.1.0"
+  dependencies:
+    "@emotion/hash": ^0.9.0
+    "@emotion/memoize": ^0.8.0
+    "@emotion/unitless": ^0.8.0
+    "@emotion/utils": ^1.2.0
+    csstype: ^3.0.2
+  checksum: 8f22f83194ad76cb3bbee481daa57fdc65ca3078a5db9e219c04151341ef93af80c7057aea17b64446682d275918f7ecc0c20e977c1af153c79a1485503fe717
+  languageName: node
+  linkType: hard
+
+"@emotion/sheet@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@emotion/sheet@npm:1.2.0"
+  checksum: b3771e47963d36c179f9a1119055d7e5d18e2718e73ebe2b4b1c56f4bbf4ea6b12c50bbc52cd502f03f7981beb2fbb3fee2638b6f5ef6c5f223b06f8bf88ec7b
   languageName: node
   linkType: hard
 
@@ -2065,17 +2114,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/utils@npm:^1.0.0, @emotion/utils@npm:^1.1.0":
+"@emotion/unitless@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@emotion/unitless@npm:0.8.0"
+  checksum: 176141117ed23c0eb6e53a054a69c63e17ae532ec4210907a20b2208f91771821835f1c63dd2ec63e30e22fcc984026d7f933773ee6526dd038e0850919fae7a
+  languageName: node
+  linkType: hard
+
+"@emotion/utils@npm:^1.0.0":
   version: 1.1.0
   resolution: "@emotion/utils@npm:1.1.0"
   checksum: d3b681ca3a23b07033ac6c6937e71010a5549ac8ccec325eb6c91a7e48d9a73db83fa5dadc58be981bb125d7c00fedca868ea4362b1da9e02866615f96be4df1
   languageName: node
   linkType: hard
 
-"@emotion/weak-memoize@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "@emotion/weak-memoize@npm:0.2.5"
-  checksum: 27d402b0c683b94658220b6d47840346ee582329ca2a15ec9c233492e0f1a27687ccb233b76eedc922f2e185e444cc89f7b97a81a1d3e5ae9f075bab08e965ea
+"@emotion/utils@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@emotion/utils@npm:1.2.0"
+  checksum: 55457a49ddd4db6a014ea0454dc09eaa23eedfb837095c8ff90470cb26a303f7ceb5fcc1e2190ef64683e64cfd33d3ba3ca3109cd87d12bc9e379e4195c9a4dd
+  languageName: node
+  linkType: hard
+
+"@emotion/weak-memoize@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@emotion/weak-memoize@npm:0.3.0"
+  checksum: f43ef4c8b7de70d9fa5eb3105921724651e4188e895beb71f0c5919dc899a7b8743e1fdd99d38b9092dd5722c7be2312ebb47fbdad0c4e38bea58f6df5885cc0
   languageName: node
   linkType: hard
 
@@ -2616,19 +2679,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/bmp@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/bmp@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-    bmp-js: ^0.1.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: 569b04af442c5c719f47acb9975eeb2ee93df119c03ea2255497e7f823dc2d36fb298b5796051107da0373ec77fe15fb815214431909711a04544b020abe890b
-  languageName: node
-  linkType: hard
-
 "@jimp/bmp@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/bmp@npm:0.16.1"
@@ -2639,25 +2689,6 @@ __metadata:
   peerDependencies:
     "@jimp/custom": ">=0.3.5"
   checksum: fa656b93c3fd2a009381d26174c5b421813a085d8b8ce600b0cd4f989e594671bcc32d0fb72c573d6d7ee4dc4283e1929cef066beb7967368f3a6e30a26c2992
-  languageName: node
-  linkType: hard
-
-"@jimp/core@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/core@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-    any-base: ^1.1.0
-    buffer: ^5.2.0
-    exif-parser: ^0.1.12
-    file-type: ^9.0.0
-    load-bmfont: ^1.3.1
-    mkdirp: ^0.5.1
-    phin: ^2.9.1
-    pixelmatch: ^4.0.2
-    tinycolor2: ^1.4.1
-  checksum: fdd1c72717522bccf1b72425154c35cdc999857c3f82f8150d370008399b5eef3d28bead9c078e32454055b4b1ee7a6f5d570707077904346e796aac289f78d0
   languageName: node
   linkType: hard
 
@@ -2680,16 +2711,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/custom@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/custom@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/core": ^0.14.0
-  checksum: e72fe3ba41f60d9649236d700bbbc90fb04166d35ab6e2de0ab9bc2374c6d9342ac01f538f6070df647d9db5a740f67e6b4623901c5f565fcb4ec7986c7d720f
-  languageName: node
-  linkType: hard
-
 "@jimp/custom@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/custom@npm:0.16.1"
@@ -2697,20 +2718,6 @@ __metadata:
     "@babel/runtime": ^7.7.2
     "@jimp/core": ^0.16.1
   checksum: 7f65ba4f62ff5495a0c679d9acf052500a672a44b9626732ba1481e8710b3ff822468c4df94a06ad27dac8b3237886aa689278ce122314a7ed3a272f43956389
-  languageName: node
-  linkType: hard
-
-"@jimp/gif@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/gif@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-    gifwrap: ^0.9.2
-    omggif: ^1.0.9
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: 67ac904830ee67d0aa745a3f7069f7f66cb5470a2dbb91927ced6719d310014887652b94ee3603b6c1061272ae35f4f502131823483aee82dfacf73bda880c36
   languageName: node
   linkType: hard
 
@@ -2728,19 +2735,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/jpeg@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/jpeg@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-    jpeg-js: ^0.4.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: 1508548a77ac6dede795d511cacba6e024dcd38ec85fff93a5b9ad7581d711e0c9b52e2716a099ddfcbab7107ff9f4890bf516c765596df8f7b22e8fdea2b21a
-  languageName: node
-  linkType: hard
-
 "@jimp/jpeg@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/jpeg@npm:0.16.1"
@@ -2751,18 +2745,6 @@ __metadata:
   peerDependencies:
     "@jimp/custom": ">=0.3.5"
   checksum: a080d3c5f510cb6b24a052e44a42d6edde9f93fa32e4eaaf4bbdae03e0063cc85ee6db3949ca1faa4eb27bf65825571db6016d80368f96d5ec469adc69897813
-  languageName: node
-  linkType: hard
-
-"@jimp/plugin-blit@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-blit@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: 5155a13fd5b6afd405efff4623329c9b0e034f5bf83492db5d53d5ce66fbca50ba2a58dc334b8d2ef8fe7bafba203568b7b25a2d77bbe3dbc90a9e4f496e2336
   languageName: node
   linkType: hard
 
@@ -2778,18 +2760,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/plugin-blur@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-blur@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: 7361ac1076c62526699f2cb1bc9e96e4f3dbb676b5ad4276e2a8c94efe4afd63bcd0c888cd2fc2021d4eb92408a73e6bef2f1d5b16f1cf1026c9fe2a7d6c295c
-  languageName: node
-  linkType: hard
-
 "@jimp/plugin-blur@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/plugin-blur@npm:0.16.1"
@@ -2799,18 +2769,6 @@ __metadata:
   peerDependencies:
     "@jimp/custom": ">=0.3.5"
   checksum: 199f57c349fe89e8e39ff9a37f2b4ed779e4e94ea58a9ba949ac64b5bcca0629689597776bcf28dc3d319b59362efc4b12f614842591abc801775f3bfe721a03
-  languageName: node
-  linkType: hard
-
-"@jimp/plugin-circle@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-circle@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: e7a08d1527c09b131de10dc55885420ad388ac3670eb2ac99decc6828d1491fbbf564af046726f134daf23f304ffe0b087c4ef0d5ab2786286c498b05b5a4704
   languageName: node
   linkType: hard
 
@@ -2826,19 +2784,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/plugin-color@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-color@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-    tinycolor2: ^1.4.1
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: d7b28ddbc96dc033b119af13c2a6e77e0bc1811d65262c04d5781163f4f3a53be4ef847761fca3388528053cde1c0a5e4f3bac3f8222b889514d0db111628a4f
-  languageName: node
-  linkType: hard
-
 "@jimp/plugin-color@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/plugin-color@npm:0.16.1"
@@ -2849,21 +2794,6 @@ __metadata:
   peerDependencies:
     "@jimp/custom": ">=0.3.5"
   checksum: cdbc8c687a761c21fb76190b107d3ef4b869468f5458d91622245a5bac21a54c63c10ae20f732ca2584cda2469ee75451837b9a2a16d8225685d70110b14673e
-  languageName: node
-  linkType: hard
-
-"@jimp/plugin-contain@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-contain@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-    "@jimp/plugin-blit": ">=0.3.5"
-    "@jimp/plugin-resize": ">=0.3.5"
-    "@jimp/plugin-scale": ">=0.3.5"
-  checksum: 22c4cdd8c131098a665db573e4f11d27576f703adce6ea66e3bca00a34bf2004d3a9d6997dab63a66f46e70b2087399b8d7a520d821861528c20a536330a9426
   languageName: node
   linkType: hard
 
@@ -2882,21 +2812,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/plugin-cover@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-cover@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-    "@jimp/plugin-crop": ">=0.3.5"
-    "@jimp/plugin-resize": ">=0.3.5"
-    "@jimp/plugin-scale": ">=0.3.5"
-  checksum: a825400df1b0c167cfb532014c0ca32a4ea2b80662c2d96973a4cd988b38dd1c62f1f28e5398160bb2914faf575ce8b632e9fd14c8e70970389c1916cc04a71e
-  languageName: node
-  linkType: hard
-
 "@jimp/plugin-cover@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/plugin-cover@npm:0.16.1"
@@ -2912,18 +2827,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/plugin-crop@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-crop@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: 38e4fb98c1a643fc5c2e3c53846b7d2c1250a80e633ebdcdc698131159d74c18883d24da76a09cef881733524d2a25f696ff8507da101c411ad84412efd1628f
-  languageName: node
-  linkType: hard
-
 "@jimp/plugin-crop@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/plugin-crop@npm:0.16.1"
@@ -2933,18 +2836,6 @@ __metadata:
   peerDependencies:
     "@jimp/custom": ">=0.3.5"
   checksum: d38f10a8d56d3a5f6d29325e649060015a0631d38dcb7454f403baa493615466e7d5e07050279b88f1fdb8cb4ea6997b62ca08c80a36f0c9cd4f9f2874aefca4
-  languageName: node
-  linkType: hard
-
-"@jimp/plugin-displace@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-displace@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: d5efc1af31259ab3141e64c9a38cff47b5069a6a2972d9102b8cd82918bd4216dde2936fa24da41cea441e04a43d21c542c39150e7c141e5b3057952713a292c
   languageName: node
   linkType: hard
 
@@ -2960,18 +2851,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/plugin-dither@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-dither@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: 8e9a36071b77778b52521d0b444f1cc81bfa4c8a637ecb8a647d0730b9bf4c1f268e66f5fb4e640c3f70ed1f18ad77575e3fedd700021ae049dead4f5ae3eaee
-  languageName: node
-  linkType: hard
-
 "@jimp/plugin-dither@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/plugin-dither@npm:0.16.1"
@@ -2984,18 +2863,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/plugin-fisheye@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-fisheye@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: ae082d1eac097051b1b550442b1974f5777f77e58cc5951e2e14ed9e06f18871666ad5e4873f86920f6818b357da8a8d91220acc7dfc83a4376bc2eac269311f
-  languageName: node
-  linkType: hard
-
 "@jimp/plugin-fisheye@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/plugin-fisheye@npm:0.16.1"
@@ -3005,19 +2872,6 @@ __metadata:
   peerDependencies:
     "@jimp/custom": ">=0.3.5"
   checksum: bc6809ec57ce97dd13e51b24677525acaf93012d1c2e7dc4c604a094cf2d778a1638313868d79376a5ee7517b155e30d2eb3e73b8a01445c6aa40e38c9798125
-  languageName: node
-  linkType: hard
-
-"@jimp/plugin-flip@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-flip@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-    "@jimp/plugin-rotate": ">=0.3.5"
-  checksum: 736f17fe6ad1cdf52844963ccfc92031ff1c2deeadfa380aeab96753e97221f093598704a7a81342edda2c611a98dae0da8a89c3f2ba64c36d77d0221b9b8b40
   languageName: node
   linkType: hard
 
@@ -3034,18 +2888,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/plugin-gaussian@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-gaussian@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: 44f23c7ce26921d242912d616e73cb57e667dfc9d6387f6ca1f34de18556adc52c49df125b91be275b1d8bfc1c24aa1fcc6d0290777c56eb9c2df32225163ec3
-  languageName: node
-  linkType: hard
-
 "@jimp/plugin-gaussian@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/plugin-gaussian@npm:0.16.1"
@@ -3055,18 +2897,6 @@ __metadata:
   peerDependencies:
     "@jimp/custom": ">=0.3.5"
   checksum: 2cbc3f2c70e30771329a9833368b7cbb04501a6e63a4d6ab3005ebdafe065749774a10b833836e694543654429f9e72be848acc8520f481de1213953e2d954b6
-  languageName: node
-  linkType: hard
-
-"@jimp/plugin-invert@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-invert@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: 8b180fab06e48abdcc41645928b61b69b393b90c8c2d549fae32e0e2136db85fdd8138c3267873b2b6086e39ab25b80a464757af56dba8fbc04e9deb2620de3a
   languageName: node
   linkType: hard
 
@@ -3082,18 +2912,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/plugin-mask@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-mask@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: 9a110dca77da17e699b5d8d1254beab09beb3ebbd854287caaf7cc4e1e8866e6931eaf23e803a236dd94855d5e9cfd3e6bb420e2eb979dac48ce2f1e39d6dc4c
-  languageName: node
-  linkType: hard
-
 "@jimp/plugin-mask@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/plugin-mask@npm:0.16.1"
@@ -3106,18 +2924,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/plugin-normalize@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-normalize@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: d88b64eafebe41626880736e8a8ad5def6ee8bde339a97df16e36a4b14245dd0f8fba0332d49c50646a561a9c35a3e8ab3b20ac8e4431bcb206bd14ed8dece4f
-  languageName: node
-  linkType: hard
-
 "@jimp/plugin-normalize@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/plugin-normalize@npm:0.16.1"
@@ -3127,20 +2933,6 @@ __metadata:
   peerDependencies:
     "@jimp/custom": ">=0.3.5"
   checksum: 277b48c48e88ccf183364b7d67991c085b5b5ca6606114075c2cfc2f2966f1da4ca073a10c2c63325c7379a8ac1b1d16fdb8e6026f30cc0c5555f286b0125fb3
-  languageName: node
-  linkType: hard
-
-"@jimp/plugin-print@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-print@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-    load-bmfont: ^1.4.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-    "@jimp/plugin-blit": ">=0.3.5"
-  checksum: ccadcf8f38746a63930bdfa0fab94531f88a3db0cce1551463e9d51f1d8ca1cb523bc47b556758ec89cf91012387100e3a1e0d96bd2b7f83059cabd10ad2c98d
   languageName: node
   linkType: hard
 
@@ -3158,18 +2950,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/plugin-resize@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-resize@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: a441c7e047e5a5821bb72a4176e2dfdb159c2215473e8b4519d3eb8ea5be2e7b7b1effe4af4df7776cb21a55bcd1296a09401b88fdc70cf3985801b64c6669bf
-  languageName: node
-  linkType: hard
-
 "@jimp/plugin-resize@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/plugin-resize@npm:0.16.1"
@@ -3179,21 +2959,6 @@ __metadata:
   peerDependencies:
     "@jimp/custom": ">=0.3.5"
   checksum: 52d0a919277af0545de8dbb7789acb73c1d8cf69b0a960716a41fef6555618d8dcf54bb4268a5c4bf07bf3a07d53e1cfd1a19620033f00c8cdc513dfb2c0ae6b
-  languageName: node
-  linkType: hard
-
-"@jimp/plugin-rotate@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-rotate@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-    "@jimp/plugin-blit": ">=0.3.5"
-    "@jimp/plugin-crop": ">=0.3.5"
-    "@jimp/plugin-resize": ">=0.3.5"
-  checksum: aba9eea50968c68e704c2335ee01a3a58c179fa0ebbbb6e3f52ae1e632e235d3795c23deab0c24accb627e6918dbfd9b0e1a58e1fc008a71167232508de5e95d
   languageName: node
   linkType: hard
 
@@ -3212,19 +2977,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/plugin-scale@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-scale@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-    "@jimp/plugin-resize": ">=0.3.5"
-  checksum: e236a8d80f2dc9052d891307aefc0e3680ed0461e6c82fffab4f474494694064d25c9ed087a4b81bac4e11a71a5a475bbc6bff1fcb9aafe667ea776ccdf9bb87
-  languageName: node
-  linkType: hard
-
 "@jimp/plugin-scale@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/plugin-scale@npm:0.16.1"
@@ -3235,20 +2987,6 @@ __metadata:
     "@jimp/custom": ">=0.3.5"
     "@jimp/plugin-resize": ">=0.3.5"
   checksum: cec394973b1d3665631d910614256a2cc5f3cc05187f8125bd470f9d447123dec9f78cac39d60051ffa192d627eda2f7913d82410ec186d3e1abe4aa09bd211a
-  languageName: node
-  linkType: hard
-
-"@jimp/plugin-shadow@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-shadow@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-    "@jimp/plugin-blur": ">=0.3.5"
-    "@jimp/plugin-resize": ">=0.3.5"
-  checksum: 6f037fdc807a5721daa1dd49bb908836b3fe06e5f7dbef58c784c4525409ab10bf8100843a4ffa078b994c29bee11f46dd9e461a3a8a34f5a7eddb82b34008e0
   languageName: node
   linkType: hard
 
@@ -3266,20 +3004,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/plugin-threshold@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugin-threshold@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-    "@jimp/plugin-color": ">=0.8.0"
-    "@jimp/plugin-resize": ">=0.8.0"
-  checksum: d904bc1e8c97f971c094f297cb7b64f713f8fcbc26a19a0b29be62c7f82459626790881174a91e661dd7502a9630a23737574b35eb96a153705e444be712129c
-  languageName: node
-  linkType: hard
-
 "@jimp/plugin-threshold@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/plugin-threshold@npm:0.16.1"
@@ -3291,39 +3015,6 @@ __metadata:
     "@jimp/plugin-color": ">=0.8.0"
     "@jimp/plugin-resize": ">=0.8.0"
   checksum: 9a206bd3fa8f539e57528772a04ebbb6dad20822f45ef0cda87bff3b451b69b3e01faed796270e7a9b2fc3141db115fc71b59b608ee19744ebf01909ac715cc0
-  languageName: node
-  linkType: hard
-
-"@jimp/plugins@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/plugins@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/plugin-blit": ^0.14.0
-    "@jimp/plugin-blur": ^0.14.0
-    "@jimp/plugin-circle": ^0.14.0
-    "@jimp/plugin-color": ^0.14.0
-    "@jimp/plugin-contain": ^0.14.0
-    "@jimp/plugin-cover": ^0.14.0
-    "@jimp/plugin-crop": ^0.14.0
-    "@jimp/plugin-displace": ^0.14.0
-    "@jimp/plugin-dither": ^0.14.0
-    "@jimp/plugin-fisheye": ^0.14.0
-    "@jimp/plugin-flip": ^0.14.0
-    "@jimp/plugin-gaussian": ^0.14.0
-    "@jimp/plugin-invert": ^0.14.0
-    "@jimp/plugin-mask": ^0.14.0
-    "@jimp/plugin-normalize": ^0.14.0
-    "@jimp/plugin-print": ^0.14.0
-    "@jimp/plugin-resize": ^0.14.0
-    "@jimp/plugin-rotate": ^0.14.0
-    "@jimp/plugin-scale": ^0.14.0
-    "@jimp/plugin-shadow": ^0.14.0
-    "@jimp/plugin-threshold": ^0.14.0
-    timm: ^1.6.1
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: 62f4809915db2ca36a34b98e2910dffa46b126ffafd959980115cbb0424331028bf0f649a84243dd09b21a26685b44febdde6a38bd9c78935d979ee91ac657c7
   languageName: node
   linkType: hard
 
@@ -3360,19 +3051,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/png@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/png@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/utils": ^0.14.0
-    pngjs: ^3.3.3
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: dc2994e5b5c1bf73bd15b92c8afce37b9769c4b16a0b7404a894049dd16e64561c9f471d78cc622c728d17e1f4c79b6557fd1b561e0707202e4997656676fb47
-  languageName: node
-  linkType: hard
-
 "@jimp/png@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/png@npm:0.16.1"
@@ -3386,18 +3064,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jimp/tiff@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/tiff@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    utif: ^2.0.1
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: 0a71674458cae944649ba0e049341420bcf17c394a51bfc32a81cf95a719329d5a6038fcd6f020933ca8760eee0ecf22c86a7010a56f8f76422e1dc7575c04a6
-  languageName: node
-  linkType: hard
-
 "@jimp/tiff@npm:^0.16.1":
   version: 0.16.1
   resolution: "@jimp/tiff@npm:0.16.1"
@@ -3407,23 +3073,6 @@ __metadata:
   peerDependencies:
     "@jimp/custom": ">=0.3.5"
   checksum: b118db6b977bdc87bf23b16cccfd0f58224c18348327354306b9f738f0086166ae3f60f7e526abf1b5e0dbd33dddc9d75bfefa5c40801d8f85093277e9570e35
-  languageName: node
-  linkType: hard
-
-"@jimp/types@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/types@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/bmp": ^0.14.0
-    "@jimp/gif": ^0.14.0
-    "@jimp/jpeg": ^0.14.0
-    "@jimp/png": ^0.14.0
-    "@jimp/tiff": ^0.14.0
-    timm: ^1.6.1
-  peerDependencies:
-    "@jimp/custom": ">=0.3.5"
-  checksum: b9d840a971867ba8a2d635e9862869faed0c5a3073ae5353d34542e5b043f86eece0fc7d96a790c369cf253ec930a90811cffb7bc8ff99f7d95e2a3f1d7e2efa
   languageName: node
   linkType: hard
 
@@ -3441,16 +3090,6 @@ __metadata:
   peerDependencies:
     "@jimp/custom": ">=0.3.5"
   checksum: 62c569a21924d76ccdc4d460f40d1a7fef590a552e4fc2bf4d727ccc9003961c964c7172d5f09ef0fc6d768a31e4c4fa735dd0bbc1aa9245eebdd01d4659fdf3
-  languageName: node
-  linkType: hard
-
-"@jimp/utils@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@jimp/utils@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    regenerator-runtime: ^0.13.3
-  checksum: b9176d4b7b6c6fc1943c36fefbb0699ba9981a626192259566596f6c11e01cce56be2c85341abd042705ff1d9a6ebc021cf9e220a09579f9718fcd5b9c1cc6b3
   languageName: node
   linkType: hard
 
@@ -3626,7 +3265,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loadable/component@npm:^5.14.1":
+"@loadable/component@npm:^5.15.2":
   version: 5.15.2
   resolution: "@loadable/component@npm:5.15.2"
   dependencies:
@@ -3639,7 +3278,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdx-js/mdx@npm:^1.6.22":
+"@mdx-js/mdx@npm:1.6.22":
   version: 1.6.22
   resolution: "@mdx-js/mdx@npm:1.6.22"
   dependencies:
@@ -3666,7 +3305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdx-js/react@npm:^1.6.22":
+"@mdx-js/react@npm:1.6.22":
   version: 1.6.22
   resolution: "@mdx-js/react@npm:1.6.22"
   peerDependencies:
@@ -4299,9 +3938,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redocly/openapi-core@npm:^1.0.0-beta.50, @redocly/openapi-core@npm:^1.0.0-beta.97":
-  version: 1.0.0-beta.104
-  resolution: "@redocly/openapi-core@npm:1.0.0-beta.104"
+"@redocly/openapi-core@npm:^1.0.0-beta.104":
+  version: 1.0.0-beta.105
+  resolution: "@redocly/openapi-core@npm:1.0.0-beta.105"
   dependencies:
     "@redocly/ajv": ^8.6.4
     "@types/node": ^14.11.8
@@ -4313,18 +3952,7 @@ __metadata:
     node-fetch: ^2.6.1
     pluralize: ^8.0.0
     yaml-ast-parser: 0.0.43
-  checksum: 59962b5d57006e0af37d3a1ca8ccb925908eef49fe62f9f33f35497d9f805d9c9ec6acf7ce5b3c183cb7646c2eaebceabf58dda73d582806425badb286946dcb
-  languageName: node
-  linkType: hard
-
-"@redocly/react-dropdown-aria@npm:^2.0.11":
-  version: 2.0.12
-  resolution: "@redocly/react-dropdown-aria@npm:2.0.12"
-  peerDependencies:
-    react: ^16.8.4 || ^17.0.0
-    react-dom: ^16.8.4 || ^17.0.0
-    styled-components: ^5.1.1
-  checksum: 89273a60065515461965fa45a664f6648653c79f037c36cac201eb57e6ceabeb824342d49a9de568eb3ea1552a8e0ce64342ca1607d0b5557f1d6bfde93e5b67
+  checksum: 45302788412dda47092514f4f600d9f71d01ddb51f1c8855a8baedd0bbd480269fe247f16ea0abf08906264108fa0262bbd29ac05611a970450f69803b798370
   languageName: node
   linkType: hard
 
@@ -4395,13 +4023,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spectrum-css/actionbutton@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@spectrum-css/actionbutton@npm:2.0.0"
+"@spectrum-css/actionbutton@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@spectrum-css/actionbutton@npm:2.1.0"
   peerDependencies:
     "@spectrum-css/icon": ^3.0.22
-    "@spectrum-css/tokens": ^1.0.0-beta.2
-  checksum: 89a1c2a1156f866c1eee9812bf8548743e8417a60d0cfcf21e35665ea7e1ae1432f47b423630e10d8b33a1a5eeb8f9558c91bc821848748ff704f10cef8ee9a0
+    "@spectrum-css/tokens": ^1.0.1
+  checksum: 0b1c2de097fefe55b012bf685807c9e835cc2e6c38b2ecf24b5ac0ab0a83f51656adc4376758db9ee6412719f6802959112da4824e9c6018958cf6b6212ef321
   languageName: node
   linkType: hard
 
@@ -4480,9 +4108,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spectrum-css/dialog@npm:6.0.14":
-  version: 6.0.14
-  resolution: "@spectrum-css/dialog@npm:6.0.14"
+"@spectrum-css/dialog@npm:6.0.15":
+  version: 6.0.15
+  resolution: "@spectrum-css/dialog@npm:6.0.15"
   peerDependencies:
     "@spectrum-css/button": ^6.0.1
     "@spectrum-css/buttongroup": ^5.0.1
@@ -4492,7 +4120,7 @@ __metadata:
     "@spectrum-css/modal": ^3.0.12
     "@spectrum-css/underlay": ^2.0.21
     "@spectrum-css/vars": ^8.0.0
-  checksum: 2cd52b9a4b5522d973987104f68888e7e9d590afa743b4c6c02aebb2541b1a7a4e3c84222562527cf8080e20aea02249628ef0d473ecb6b0621d0a52be0ad666
+  checksum: f45a322a30eb90477565bad61b3a2c92d9afeecba086c5e3d3d1ea309de70fe01e8e6c91119d14c3955d9bdbff336226b22b6d9ee721b4d6a6ab976cb8bfdaaf
   languageName: node
   linkType: hard
 
@@ -4553,25 +4181,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spectrum-css/picker@npm:1.2.10":
-  version: 1.2.10
-  resolution: "@spectrum-css/picker@npm:1.2.10"
+"@spectrum-css/picker@npm:1.2.12":
+  version: 1.2.12
+  resolution: "@spectrum-css/picker@npm:1.2.12"
   peerDependencies:
     "@spectrum-css/icon": ^3.0.21
     "@spectrum-css/menu": ^4.0.0
     "@spectrum-css/popover": ^5.0.0
     "@spectrum-css/vars": ^8.0.0
-  checksum: 34d11ffc5562e9043dfa26eefd95f5463367c79fe128c61bb1765776891fd87d568692e2ffb0620d224dda8ec8c28615211a47ac2a70581724d4d8777e540704
+  checksum: 1b6b874041c028d0351e5f741fb121098f2aaa59e32d820c415def9a724d03ab27ec8307ca133888661b77efe51a1ca8456d46a99afdbe58311bb1cea54574a8
   languageName: node
   linkType: hard
 
-"@spectrum-css/popover@npm:5.0.17":
-  version: 5.0.17
-  resolution: "@spectrum-css/popover@npm:5.0.17"
+"@spectrum-css/popover@npm:5.0.18":
+  version: 5.0.18
+  resolution: "@spectrum-css/popover@npm:5.0.18"
   peerDependencies:
     "@spectrum-css/dialog": ^6.0.0
     "@spectrum-css/vars": ^8.0.0
-  checksum: 1e92bbde630421e8756e30cfdb1d5acb785fe8ad79920df4d0f153d9834ca7bad91759e4db4c155bd21521e2d57f564227fadf52d647bdad82ed4c1e8cbf49a1
+  checksum: 368a94ae38dc59a83f48c178fb812bbef48dd8aaebfbdc8d8a47d7cd84304c966b795bf34db5d1c7300f430d78e977b51a4dd6319b23e2ff70acc54835246a52
   languageName: node
   linkType: hard
 
@@ -4615,14 +4243,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spectrum-css/tabs@npm:3.2.17":
-  version: 3.2.17
-  resolution: "@spectrum-css/tabs@npm:3.2.17"
+"@spectrum-css/tabs@npm:3.2.19":
+  version: 3.2.19
+  resolution: "@spectrum-css/tabs@npm:3.2.19"
   peerDependencies:
     "@spectrum-css/menu": ^4.0.0
     "@spectrum-css/picker": ^1.2.7
     "@spectrum-css/vars": ^8.0.0
-  checksum: 6d41b8e3000ae2b2eefcbbb1c4569fc31bb54610b64cca6863ea6e55dc822c8c6d13912822c0b32bcdb67beac36f8b59810b15b717190abb6b20b4b340468f63
+  checksum: a80feccd45497e683d7d5e59b2d9947a38fbefca811102d8917d218636cbc74eff3866713c3d2def0f3b80726fdac8412ddb05eb7604561a1841fe465ce70f34
   languageName: node
   linkType: hard
 
@@ -5024,13 +4652,6 @@ __metadata:
   version: 14.18.22
   resolution: "@types/node@npm:14.18.22"
   checksum: 5cec8276b834b8988f0af69655423e816729a5757d2015a3199156bdc98ea55206338fad752b26236c55d431dce24eb973b4f5a8918f8e6b17056ffcc12edc08
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^15.6.1":
-  version: 15.14.9
-  resolution: "@types/node@npm:15.14.9"
-  checksum: 49f7f0522a3af4b8389aee660e88426490cd54b86356672a1fedb49919a8797c00d090ec2dcc4a5df34edc2099d57fc2203d796c4e7fbd382f2022ccd789eee7
   languageName: node
   linkType: hard
 
@@ -5668,25 +5289,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"algoliasearch@npm:4.10.4":
-  version: 4.10.4
-  resolution: "algoliasearch@npm:4.10.4"
+"algoliasearch@npm:4.14.2":
+  version: 4.14.2
+  resolution: "algoliasearch@npm:4.14.2"
   dependencies:
-    "@algolia/cache-browser-local-storage": 4.10.4
-    "@algolia/cache-common": 4.10.4
-    "@algolia/cache-in-memory": 4.10.4
-    "@algolia/client-account": 4.10.4
-    "@algolia/client-analytics": 4.10.4
-    "@algolia/client-common": 4.10.4
-    "@algolia/client-personalization": 4.10.4
-    "@algolia/client-search": 4.10.4
-    "@algolia/logger-common": 4.10.4
-    "@algolia/logger-console": 4.10.4
-    "@algolia/requester-browser-xhr": 4.10.4
-    "@algolia/requester-common": 4.10.4
-    "@algolia/requester-node-http": 4.10.4
-    "@algolia/transporter": 4.10.4
-  checksum: fa3ab323e4a017597ba8f69b7a6f3188870fdb644bdd111a1acdc246966ff9739679b807aa3d748ebb73d0b63e01e529566de7f3a0d5b98ba8ec06fc1009861c
+    "@algolia/cache-browser-local-storage": 4.14.2
+    "@algolia/cache-common": 4.14.2
+    "@algolia/cache-in-memory": 4.14.2
+    "@algolia/client-account": 4.14.2
+    "@algolia/client-analytics": 4.14.2
+    "@algolia/client-common": 4.14.2
+    "@algolia/client-personalization": 4.14.2
+    "@algolia/client-search": 4.14.2
+    "@algolia/logger-common": 4.14.2
+    "@algolia/logger-console": 4.14.2
+    "@algolia/requester-browser-xhr": 4.14.2
+    "@algolia/requester-common": 4.14.2
+    "@algolia/requester-node-http": 4.14.2
+    "@algolia/transporter": 4.14.2
+  checksum: 4365a0d0f066f3ad6798e4dd0d7487cba1cf4546dac27e66cb84865f91955d6537dc5bad4e71d4bf22a68c0b721b1e6f20109203566ca1a252fe2713d713c0fd
   languageName: node
   linkType: hard
 
@@ -7182,7 +6803,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cheerio@npm:^1.0.0-rc.10, cheerio@npm:^1.0.0-rc.5":
+"cheerio@npm:^1.0.0-rc.10":
   version: 1.0.0-rc.12
   resolution: "cheerio@npm:1.0.0-rc.12"
   dependencies:
@@ -7254,7 +6875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:^2.2.6, classnames@npm:^2.3.1":
+"classnames@npm:^2.3.1":
   version: 2.3.1
   resolution: "classnames@npm:2.3.1"
   checksum: 14db8889d56c267a591f08b0834989fe542d47fac659af5a539e110cc4266694e8de86e4e3bbd271157dbd831361310a8293e0167141e80b0f03a0f175c80960
@@ -7434,7 +7055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color@npm:^4.0.1, color@npm:^4.2.3":
+"color@npm:^4.2.3":
   version: 4.2.3
   resolution: "color@npm:4.2.3"
   dependencies:
@@ -7499,7 +7120,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "commerce-frontend-core@workspace:."
   dependencies:
-    "@adobe/gatsby-theme-aio": 4.3.0
+    "@adobe/gatsby-theme-aio": 4.4.2
     gatsby: 4.19.1
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -7737,10 +7358,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.16.3, core-js@npm:^3.22.3":
+"core-js@npm:^3.22.3":
   version: 3.23.5
   resolution: "core-js@npm:3.23.5"
   checksum: 0277d46b151126c5d90411e8e6b0d338abe2aaa695a132c360203a3772c620f849622c4fab8bfd7a46eec6933d5fe90f32f7167779d419bda699ff7808605757
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^3.24.0":
+  version: 3.24.1
+  resolution: "core-js@npm:3.24.1"
+  checksum: 6fb5bf0fd9e9f3e69d95616dd03332fea6758a715d2628c108b5faf17b48b0f580e90c4febb0a523c4665b0991a810de16289f86187fe79d70cc722dbd3edf0e
   languageName: node
   linkType: hard
 
@@ -8287,7 +7915,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:2, debug@npm:2.6.9, debug@npm:^2.2.0, debug@npm:^2.6.0, debug@npm:^2.6.9":
+"debug@npm:2, debug@npm:2.6.9, debug@npm:^2.6.0, debug@npm:^2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
   dependencies:
@@ -8710,7 +8338,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom7@npm:^4.0.2":
+"dom7@npm:^4.0.4":
   version: 4.0.4
   resolution: "dom7@npm:4.0.4"
   dependencies:
@@ -10308,7 +9936,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^10.0.0, fs-extra@npm:^10.1.0":
+"fs-extra@npm:^10.1.0":
   version: 10.1.0
   resolution: "fs-extra@npm:10.1.0"
   dependencies:
@@ -10460,24 +10088,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-core-utils@npm:^2.2.0-next.0":
-  version: 2.14.0
-  resolution: "gatsby-core-utils@npm:2.14.0"
-  dependencies:
-    "@babel/runtime": ^7.15.4
-    ci-info: 2.0.0
-    configstore: ^5.0.1
-    file-type: ^16.5.3
-    fs-extra: ^10.0.0
-    got: ^11.8.2
-    node-object-hash: ^2.3.9
-    proper-lockfile: ^4.1.2
-    tmp: ^0.2.1
-    xdg-basedir: ^4.0.0
-  checksum: b33a1a1e9a9adc53bbc4053e1e1fbfb066817a2e922058990f20612afb19c351dfb77919231553e2051b734a339957f716012d741823d0b7c387a2b7ccc3ea7b
-  languageName: node
-  linkType: hard
-
 "gatsby-core-utils@npm:^3.19.0":
   version: 3.19.0
   resolution: "gatsby-core-utils@npm:3.19.0"
@@ -10498,6 +10108,29 @@ __metadata:
     tmp: ^0.2.1
     xdg-basedir: ^4.0.0
   checksum: 80c1f069d29195636d211fc900e40db8dfb855c6221206cf2b4d401ac137d0c9df790938a9f3830d2ea3049157bca7c661b5b4ab07ac00bc6b71e3beb3c2254d
+  languageName: node
+  linkType: hard
+
+"gatsby-core-utils@npm:^3.20.0":
+  version: 3.20.0
+  resolution: "gatsby-core-utils@npm:3.20.0"
+  dependencies:
+    "@babel/runtime": ^7.15.4
+    ci-info: 2.0.0
+    configstore: ^5.0.1
+    fastq: ^1.13.0
+    file-type: ^16.5.3
+    fs-extra: ^10.1.0
+    got: ^11.8.5
+    import-from: ^4.0.0
+    lmdb: 2.5.3
+    lock: ^1.1.0
+    node-object-hash: ^2.3.10
+    proper-lockfile: ^4.1.2
+    resolve-from: ^5.0.0
+    tmp: ^0.2.1
+    xdg-basedir: ^4.0.0
+  checksum: 9570a4fba57f14ee70229cfe1fd24191597c728520493303c42dd8ae3da5c0e50736ea7e554e9ac7e569fa12d00675a0988e2ee5d7b119a649ae3d4ca102dba0
   languageName: node
   linkType: hard
 
@@ -10578,22 +10211,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-plugin-algolia@npm:^0.22.1":
-  version: 0.22.2
-  resolution: "gatsby-plugin-algolia@npm:0.22.2"
+"gatsby-plugin-algolia@npm:^0.26.0":
+  version: 0.26.0
+  resolution: "gatsby-plugin-algolia@npm:0.26.0"
   dependencies:
     algoliasearch: ^4.9.1
     deep-equal: ^2.0.5
     lodash.chunk: ^4.2.0
   peerDependencies:
-    gatsby: ^2.0.0 || ^3.0.0
-  checksum: 1e4739c3d84a6c4f8868fa3efb6f0ed4ff7419e4e353096bf6c0c9eb4277b7957e4cefbfcc7510c8a5e16c6d3fe9b920ace3db670bf631e55910296052fcff87
+    gatsby: ^2.0.0 || ^3.0.0 || ^4.0.0
+  checksum: 1f6c3b8636a30f512e95f69461505adedd06d27d84e42d62bf8d04e51b01d5b7c4882837fdd0d210af3af5418890f0544c65bb96f6215a1005402fdd20df605b
   languageName: node
   linkType: hard
 
-"gatsby-plugin-emotion@npm:^7.13.0":
-  version: 7.19.0
-  resolution: "gatsby-plugin-emotion@npm:7.19.0"
+"gatsby-plugin-emotion@npm:^7.19.0":
+  version: 7.20.0
+  resolution: "gatsby-plugin-emotion@npm:7.20.0"
   dependencies:
     "@babel/runtime": ^7.15.4
     "@emotion/babel-preset-css-prop": ^11.2.0
@@ -10601,18 +10234,18 @@ __metadata:
     "@babel/core": ^7.11.6
     "@emotion/react": ^11.0.0
     gatsby: ^4.0.0-next
-  checksum: e398113de0c89c0d37687c3eb5f5c4375a21bf8be6448f6161dbe03a33f0482fd6cee352b9db4239e06c40c8f49891bd5894515a5158fc279d2446d5685ce103
+  checksum: 7a0afcb25f0cef26531e822a0cb57f38d6fd64af1597fa989a96f0887eafc0c1cf4833e7948ea11663af95634e885f9423bc742a3b185054b920c4a94e32d03d
   languageName: node
   linkType: hard
 
-"gatsby-plugin-layout@npm:^3.13.0":
-  version: 3.19.0
-  resolution: "gatsby-plugin-layout@npm:3.19.0"
+"gatsby-plugin-layout@npm:^3.19.0":
+  version: 3.20.0
+  resolution: "gatsby-plugin-layout@npm:3.20.0"
   dependencies:
     "@babel/runtime": ^7.15.4
   peerDependencies:
     gatsby: ^4.0.0-next
-  checksum: 3ae18db1fd33f0fd235cdc0516654605aab7597375a6a136f126870ea6c9b50243c6710b364a7927bc86379264c3919ca549c4f5163fee63277ea2f1dc1dfc18
+  checksum: 81419ee733604a9112e9b7a213aa60a7198cfc96722a5bb6bd495f2ec0713e5a13ebdc9011e78fe25bdb4dfffbc4a8dc1b4fe121443e8ddf61145991a2b3fe01
   languageName: node
   linkType: hard
 
@@ -10630,9 +10263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-plugin-mdx@npm:^3.13.0":
-  version: 3.19.0
-  resolution: "gatsby-plugin-mdx@npm:3.19.0"
+"gatsby-plugin-mdx@npm:^3.19.0":
+  version: 3.20.0
+  resolution: "gatsby-plugin-mdx@npm:3.20.0"
   dependencies:
     "@babel/core": ^7.15.5
     "@babel/generator": ^7.15.4
@@ -10650,7 +10283,7 @@ __metadata:
     escape-string-regexp: ^1.0.5
     eval: ^0.1.4
     fs-extra: ^10.1.0
-    gatsby-core-utils: ^3.19.0
+    gatsby-core-utils: ^3.20.0
     gray-matter: ^4.0.2
     json5: ^2.1.3
     loader-utils: ^1.4.0
@@ -10678,7 +10311,7 @@ __metadata:
     gatsby: ^4.0.0-next
     react: ^16.9.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0
-  checksum: ad712bf550460a89bce460b929f282b00ded8d00bd083847b018387b0bb239fa5ad36392784eec655f6592ebd2188a6ece946b655b49939f9d4e882a12603427
+  checksum: cd9c68e250f8050233d9fb2d1908df6f66454933382ad33cf749d1d4a8c6d948d368366c2cad473124c8fb9e13a3ad967918c0cb45b700fcf3d380da9b4423df
   languageName: node
   linkType: hard
 
@@ -10703,9 +10336,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-plugin-preact@npm:^6.13.0":
-  version: 6.19.0
-  resolution: "gatsby-plugin-preact@npm:6.19.0"
+"gatsby-plugin-preact@npm:^6.19.0":
+  version: 6.20.0
+  resolution: "gatsby-plugin-preact@npm:6.20.0"
   dependencies:
     "@babel/runtime": ^7.15.4
     "@gatsbyjs/webpack-hot-middleware": ^2.25.3
@@ -10715,25 +10348,25 @@ __metadata:
     gatsby: ^4.0.0-next
     preact: ^10.3.4
     preact-render-to-string: ^5.1.8
-  checksum: a34a5122a18e75a2469f2b892c583a02ec684c5764861900ed0684cb99e0f63dbf544dfdfd1375b24bce6f6ec4035d323c2f23bb3a598be7f9f0cf4bbc04cf4a
+  checksum: 63a01ecfef14c1c6f8a4625f2f96ff6c661164477d05a90379a99564d3ff4f0276a0b4335ead12a2bf90ecc7dd7561590eefd5bef051d4eb72135b352b5aec5d
   languageName: node
   linkType: hard
 
-"gatsby-plugin-react-helmet@npm:^5.13.0":
-  version: 5.19.0
-  resolution: "gatsby-plugin-react-helmet@npm:5.19.0"
+"gatsby-plugin-react-helmet@npm:^5.19.0":
+  version: 5.20.0
+  resolution: "gatsby-plugin-react-helmet@npm:5.20.0"
   dependencies:
     "@babel/runtime": ^7.15.4
   peerDependencies:
     gatsby: ^4.0.0-next
     react-helmet: ^5.1.3 || ^6.0.0
-  checksum: 7890d998b7a8c2f5b577bc2baa86545d995bce1f441a8b838052aa08cd25ff00b7fc5dcef52a732647951a052068367623a8838d574498c95443ad86bed806ee
+  checksum: d028dea0aadc8b489b9bd912e53d93df8580c48fc070492a4fad09039e8a64e90456f94c7459dbd1d2543e03ca2a18e73ad39dedba6cf11ffba42c5a2c8022a1
   languageName: node
   linkType: hard
 
-"gatsby-plugin-sharp@npm:^4.13.0":
-  version: 4.19.0
-  resolution: "gatsby-plugin-sharp@npm:4.19.0"
+"gatsby-plugin-sharp@npm:^4.19.0":
+  version: 4.20.0
+  resolution: "gatsby-plugin-sharp@npm:4.20.0"
   dependencies:
     "@babel/runtime": ^7.15.4
     "@gatsbyjs/potrace": ^2.2.0
@@ -10742,9 +10375,9 @@ __metadata:
     debug: ^4.3.4
     filenamify: ^4.3.0
     fs-extra: ^10.1.0
-    gatsby-core-utils: ^3.19.0
-    gatsby-plugin-utils: ^3.13.0
-    gatsby-telemetry: ^3.19.0
+    gatsby-core-utils: ^3.20.0
+    gatsby-plugin-utils: ^3.14.0
+    gatsby-telemetry: ^3.20.0
     got: ^11.8.5
     lodash: ^4.17.21
     mini-svg-data-uri: ^1.4.4
@@ -10755,7 +10388,7 @@ __metadata:
     svgo: 1.3.2
   peerDependencies:
     gatsby: ^4.0.0-next
-  checksum: d3f96ed2c9a307183632f308e73ff4b83139b8b449363fda4a910e6b8f6fff7f322a5c6b37e46144ecba84b33d94da4ffc33abae5e30438524d2ac28eca78e26
+  checksum: 67db636ff1daf803b65dc4443814b765bd31f688b05586e6436adb577b7df17036320b0a5102b48910b380d5ae1854bfd111a2793d54a669e9285c4e226a1a92
   languageName: node
   linkType: hard
 
@@ -10797,6 +10430,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gatsby-plugin-utils@npm:^3.14.0":
+  version: 3.14.0
+  resolution: "gatsby-plugin-utils@npm:3.14.0"
+  dependencies:
+    "@babel/runtime": ^7.15.4
+    "@gatsbyjs/potrace": ^2.2.0
+    fastq: ^1.13.0
+    fs-extra: ^10.1.0
+    gatsby-core-utils: ^3.20.0
+    gatsby-sharp: ^0.14.0
+    graphql-compose: ^9.0.7
+    import-from: ^4.0.0
+    joi: ^17.4.2
+    mime: ^3.0.0
+    mini-svg-data-uri: ^1.4.4
+    svgo: ^2.8.0
+  peerDependencies:
+    gatsby: ^4.0.0-next
+    graphql: ^15.0.0
+  checksum: b194d10d5e2b6cf77144d019c1fb18e02360acb50e03e3b002c65e7ba1c702284d751ae7db297cd5c4db856e1a7dacd0790d63bc65b87f2168bf54ccb8b677c1
+  languageName: node
+  linkType: hard
+
 "gatsby-react-router-scroll@npm:^5.19.0":
   version: 5.19.0
   resolution: "gatsby-react-router-scroll@npm:5.19.0"
@@ -10811,9 +10467,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-remark-copy-linked-files@npm:^5.13.0":
-  version: 5.19.0
-  resolution: "gatsby-remark-copy-linked-files@npm:5.19.0"
+"gatsby-remark-autolink-headers@npm:^5.19.0":
+  version: 5.20.0
+  resolution: "gatsby-remark-autolink-headers@npm:5.20.0"
+  dependencies:
+    "@babel/runtime": ^7.15.4
+    github-slugger: ^1.3.0
+    lodash: ^4.17.21
+    mdast-util-to-string: ^2.0.0
+    unist-util-visit: ^2.0.3
+  peerDependencies:
+    gatsby: ^4.0.0-next
+    react: ^16.9.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0
+  checksum: 401632222861134cdca4d766a49f063fd9095b4cb87693918db24bb79de569970125c59a1006fea7091147e9f7e901c61321b003bdc4739ced0f5daa34bc727c
+  languageName: node
+  linkType: hard
+
+"gatsby-remark-copy-linked-files@npm:^5.19.0":
+  version: 5.20.0
+  resolution: "gatsby-remark-copy-linked-files@npm:5.20.0"
   dependencies:
     "@babel/runtime": ^7.15.4
     cheerio: ^1.0.0-rc.10
@@ -10825,30 +10498,29 @@ __metadata:
     unist-util-visit: ^2.0.3
   peerDependencies:
     gatsby: ^4.0.0-next
-  checksum: bd093b8ef62896f992170cf4d4d14929c2741f1596a19c4db1d9840a67f34c1091f5037150ed9e6e3b09837b72eb333a8eb5bde3861338cec8d91e4b471de9f0
+  checksum: babc19c2405cc28048a75459877beaa2f109e0c0967aaa52dfa5e332dba26eaaadb17d82722b26a24d6d9fd3d6b5ca43a9f33e34816188c9f19f6071f7c35c17
   languageName: node
   linkType: hard
 
-"gatsby-remark-images-remote@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "gatsby-remark-images-remote@npm:1.1.0"
+"gatsby-remark-images@npm:^6.19.0":
+  version: 6.20.0
+  resolution: "gatsby-remark-images@npm:6.20.0"
   dependencies:
-    "@babel/runtime": ^7.12.5
-    chalk: ^4.1.0
-    cheerio: ^1.0.0-rc.5
-    gatsby-core-utils: ^2.2.0-next.0
+    "@babel/runtime": ^7.15.4
+    "@gatsbyjs/potrace": ^2.2.0
+    chalk: ^4.1.2
+    cheerio: ^1.0.0-rc.10
+    gatsby-core-utils: ^3.20.0
     is-relative-url: ^3.0.0
     lodash: ^4.17.21
-    mdast-util-definitions: ^1.2.5
-    potrace: ^2.1.8
-    query-string: ^6.13.3
-    unist-util-select: ^1.5.0
-    unist-util-visit-parents: ^2.1.2
+    mdast-util-definitions: ^4.0.0
+    query-string: ^6.14.1
+    unist-util-select: ^3.0.4
+    unist-util-visit-parents: ^3.1.1
   peerDependencies:
-    gatsby: ^3.0.0
-    gatsby-plugin-sharp: ^3.0.0
-    gatsby-source-filesystem: ^3.0.0
-  checksum: f8456e14f54d458acbc14fb3cac68db1649b533f9c178dde1021da3b4690bfed8979167f1f29706a4ad67e7c7fff2fb9566e82e9c0e9388f2f5a1141aa50d5ba
+    gatsby: ^4.0.0-next
+    gatsby-plugin-sharp: ^4.0.0-next
+  checksum: 317ce8a3d142d72b491bec5cbe2a9f86d82c1e797cb65f89e10d3f6f371f942f041e3ba9c0f957a85a989857b102c7d6b88fb45ea5196f34dfdaab443eb84a09
   languageName: node
   linkType: hard
 
@@ -10872,15 +10544,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-source-filesystem@npm:^4.13.0":
-  version: 4.19.0
-  resolution: "gatsby-source-filesystem@npm:4.19.0"
+"gatsby-sharp@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "gatsby-sharp@npm:0.14.0"
+  dependencies:
+    "@types/sharp": ^0.30.0
+    sharp: ^0.30.3
+  checksum: 753e43bba753e73723987eb9cb0db909e01e1b0353ac0f0e732961050d23f97226aac2f329700ac366b5b33ede6f5100cdffefe537f890af2393d0d720d6e36d
+  languageName: node
+  linkType: hard
+
+"gatsby-source-filesystem@npm:^4.19.0":
+  version: 4.20.0
+  resolution: "gatsby-source-filesystem@npm:4.20.0"
   dependencies:
     "@babel/runtime": ^7.15.4
     chokidar: ^3.5.3
     file-type: ^16.5.3
     fs-extra: ^10.1.0
-    gatsby-core-utils: ^3.19.0
+    gatsby-core-utils: ^3.20.0
     got: ^9.6.0
     md5-file: ^5.0.0
     mime: ^2.5.2
@@ -10890,7 +10572,7 @@ __metadata:
     xstate: ^4.26.1
   peerDependencies:
     gatsby: ^4.0.0-next
-  checksum: b609e5ec45100f5df881faddf38aafdc78309cd6ef03236ed0440746a54afdeadb3e872f8e1bc3b47074ed0097f85e2156f5fd02213cca09fb9d1ffda3f7b7c7
+  checksum: 16c0eed83cafe879a5117b2abd1e8c3f4b20825e98583ceeb8479dfa1ed6e5f43074b02d7ad64dcbf3fee9b6bcab47e96c1fe0e5f6ecac4aac0efc809974f967
   languageName: node
   linkType: hard
 
@@ -10915,12 +10597,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-transformer-remark@npm:^5.1.1":
-  version: 5.19.0
-  resolution: "gatsby-transformer-remark@npm:5.19.0"
+"gatsby-telemetry@npm:^3.20.0":
+  version: 3.20.0
+  resolution: "gatsby-telemetry@npm:3.20.0"
+  dependencies:
+    "@babel/code-frame": ^7.14.0
+    "@babel/runtime": ^7.15.4
+    "@turist/fetch": ^7.2.0
+    "@turist/time": ^0.0.2
+    async-retry-ng: ^2.0.1
+    boxen: ^4.2.0
+    configstore: ^5.0.1
+    fs-extra: ^10.1.0
+    gatsby-core-utils: ^3.20.0
+    git-up: ^4.0.5
+    is-docker: ^2.2.1
+    lodash: ^4.17.21
+    node-fetch: ^2.6.7
+  checksum: 74bb4ba010a2dcd4783ebec13b76cabac9413cf5561c389bb52e1d57d4d939aa05cb61eca3cd0135e5a0477b99ba45f3a25a97bf80d39b45fbf7c33522bcafd6
+  languageName: node
+  linkType: hard
+
+"gatsby-transformer-remark@npm:^5.19.0":
+  version: 5.20.0
+  resolution: "gatsby-transformer-remark@npm:5.20.0"
   dependencies:
     "@babel/runtime": ^7.15.4
-    gatsby-core-utils: ^3.19.0
+    gatsby-core-utils: ^3.20.0
     gray-matter: ^4.0.3
     hast-util-raw: ^6.0.2
     hast-util-to-html: ^7.1.3
@@ -10943,27 +10646,27 @@ __metadata:
     unist-util-visit: ^2.0.3
   peerDependencies:
     gatsby: ^4.0.0-next
-  checksum: f585e364d9b59419a0ce8aae2d85481288e06561d1abdb30b549201d983f5a47d708614b9170b67513bbfb0d9ca8e74d6db718e03c0ad0e4172b1736c80da8d7
+  checksum: 847c35f17a011d336af6bdee59aa456b157d29f55615248fa07b16b16d5201f73476df06fa0febe870cfa04146b462cb0c311e36ec64be52375a2169dbe97231
   languageName: node
   linkType: hard
 
-"gatsby-transformer-sharp@npm:^4.13.0":
-  version: 4.19.0
-  resolution: "gatsby-transformer-sharp@npm:4.19.0"
+"gatsby-transformer-sharp@npm:^4.19.0":
+  version: 4.20.0
+  resolution: "gatsby-transformer-sharp@npm:4.20.0"
   dependencies:
     "@babel/runtime": ^7.15.4
     "@gatsbyjs/potrace": ^2.2.0
     bluebird: ^3.7.2
     common-tags: ^1.8.2
     fs-extra: ^10.1.0
-    gatsby-plugin-utils: ^3.13.0
+    gatsby-plugin-utils: ^3.14.0
     probe-image-size: ^7.2.3
     semver: ^7.3.7
     sharp: ^0.30.3
   peerDependencies:
     gatsby: ^4.0.0-next
     gatsby-plugin-sharp: ^4.0.0-next
-  checksum: c59313bc0c69be6406a1f371a9aee25bcb7b879c82e2a733645d225333c6ce3cc2526d8096405fb95ed16caf91341fd15d8b2820f74460c5a4b74ecc16c8a90a
+  checksum: 540aef99700eafc428638638a8b008b6bcea524e81758322a9effd83dca9d5144b86e162774d5b8c553f2341d9a45a974511291febd1f6161e6f7138fb1b39b2
   languageName: node
   linkType: hard
 
@@ -11273,7 +10976,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"github-slugger@npm:^1.0.0, github-slugger@npm:^1.1.1, github-slugger@npm:^1.2.1":
+"github-slugger@npm:^1.0.0, github-slugger@npm:^1.2.1, github-slugger@npm:^1.3.0":
   version: 1.4.0
   resolution: "github-slugger@npm:1.4.0"
   checksum: 4f52e7a21f5c6a4c5328f01fe4fe13ae8881fea78bfe31f9e72c4038f97e3e70d52fb85aa7633a52c501dc2486874474d9abd22aa61cbe9b113099a495551c6b
@@ -11741,20 +11444,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hast-util-has-property@npm:^1.0.0":
-  version: 1.0.4
-  resolution: "hast-util-has-property@npm:1.0.4"
-  checksum: 23025cee6692cf9aaf70a369248901deff0886c9bd2e2f0e81735c5f67ff500d1cfd991d3c236fc1d43e02b29d2db4075ee9fd2fe0aea1a7da261f19195046e8
-  languageName: node
-  linkType: hard
-
-"hast-util-heading-rank@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "hast-util-heading-rank@npm:1.0.1"
-  checksum: 9f919ce54f3ddb2414a9ff786983c64f8d10f6e4b0bd9d591bbb9f45b9f37d1eb0821583ec708dc3961b15d9b2aebfe79e5e23868a87a4773b29ce5f0791108a
-  languageName: node
-  linkType: hard
-
 "hast-util-is-element@npm:^1.0.0":
   version: 1.1.0
   resolution: "hast-util-is-element@npm:1.1.0"
@@ -11834,13 +11523,6 @@ __metadata:
     xtend: ^4.0.0
     zwitch: ^1.0.0
   checksum: 91a36244e37df1d63c8b7e865ab0c0a25bb7396155602be005cf71d95c348e709568f80e0f891681a3711d733ad896e70642dc41a05b574eddf2e07d285408a8
-  languageName: node
-  linkType: hard
-
-"hast-util-to-string@npm:^1.0.0":
-  version: 1.0.4
-  resolution: "hast-util-to-string@npm:1.0.4"
-  checksum: 8132508d5c08d542b64979ad558e474f481011c29d5fce9b1a1fe779fc97e151b734b5c6d94f4937c4ec978b1d641977ee7f9f5ed61ea0611600764abdff7cbb
   languageName: node
   linkType: hard
 
@@ -13043,19 +12725,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jimp@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "jimp@npm:0.14.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    "@jimp/custom": ^0.14.0
-    "@jimp/plugins": ^0.14.0
-    "@jimp/types": ^0.14.0
-    regenerator-runtime: ^0.13.3
-  checksum: acf19b5e56e9b218907c975b0e9f9f4b940f2d908460df8e0b5766558f0ee038630aed4cb6526f43e182ccff0dc1ac3302e5a2c18a75e4a4d75020824ea340db
-  languageName: node
-  linkType: hard
-
 "jimp@npm:^0.16.1":
   version: 0.16.1
   resolution: "jimp@npm:0.16.1"
@@ -13086,13 +12755,6 @@ __metadata:
   version: 0.4.2
   resolution: "jpeg-js@npm:0.4.2"
   checksum: def900757c395e6376446aef5c13ed122cae1ab15308e84784d260c8d3c14d30c2092eaf32a4f57528d6e1f96a6b240a801e92122f00c9f3bb5d5c4d38df5bc0
-  languageName: node
-  linkType: hard
-
-"jpeg-js@npm:^0.4.0":
-  version: 0.4.4
-  resolution: "jpeg-js@npm:0.4.4"
-  checksum: bd7cb61aa8df40a9ee2c2106839c3df6054891e56cfc22c0ac581402e06c6295f962a4754b0b2ac50a401789131b1c6dc9df8d24400f1352168be1894833c590
   languageName: node
   linkType: hard
 
@@ -13220,7 +12882,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-pointer@npm:0.6.2, json-pointer@npm:^0.6.1, json-pointer@npm:^0.6.2":
+"json-pointer@npm:0.6.2, json-pointer@npm:^0.6.2":
   version: 0.6.2
   resolution: "json-pointer@npm:0.6.2"
   dependencies:
@@ -14055,15 +13717,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "marked@npm:0.7.0"
-  bin:
-    marked: ./bin/marked
-  checksum: 5965e990ee0497aceae1b63c479ad614773331e255c7c9feb00120813574370d03e104d062f3c52ca4d96e7c4ff726ad8ca7ef2debe53728fb73975677b6878e
-  languageName: node
-  linkType: hard
-
 "marked@npm:^4.0.15":
   version: 4.0.18
   resolution: "marked@npm:4.0.18"
@@ -14108,15 +13761,6 @@ __metadata:
   dependencies:
     unist-util-visit: ^1.1.0
   checksum: 5c2eec96bd9f231d54733bbfb4fbd83ec8e1a6ddd9084a79f502614b6868a27be8ac75946ba5871c3d291673904da1fa63a5738de9c98ac1dbfd011ebb57d853
-  languageName: node
-  linkType: hard
-
-"mdast-util-definitions@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "mdast-util-definitions@npm:1.2.5"
-  dependencies:
-    unist-util-visit: ^1.0.0
-  checksum: 955fa0f3120b0043099a8f2ee64f34707767860d4af016639ac723788db73b00bc697017be72e88ae7b8d4a039a3c1662a64768c75852ec65ce38ec00f7dd6b3
   languageName: node
   linkType: hard
 
@@ -14389,15 +14033,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mdx-embed@npm:^0.0.19":
-  version: 0.0.19
-  resolution: "mdx-embed@npm:0.0.19"
+"mdx-embed@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "mdx-embed@npm:1.0.0"
   peerDependencies:
     "@mdx-js/mdx": ^1.6.16
     "@mdx-js/react": ^1.6.16
-    react: ^16.13.1
-    react-dom: ^16.13.1
-  checksum: fcbaa1c4616cc22b3c13b18cb670b654a065c7619c39f2ee8c5c2df5e6fa2047a188487cd33c45a77ff3c6e6d7a92d6bb7f86abd9cd96ef96906f379ede05edb
+    react: ^16.9.0
+    react-dom: ^16.9.0
+  checksum: 59af0df877beae45d8e396df91a32bc21a661c136d46964f5be007cdbf157650d9f2136146acb3fe2c8ea38cfd9c773cffa53ab89bf6d8ab63179e92acbc2937
   languageName: node
   linkType: hard
 
@@ -14431,13 +14075,6 @@ __metadata:
   dependencies:
     fs-monkey: ^1.0.3
   checksum: fab88266dc576dc4999e38bdf531d703fb798affac2e0dd3fc17470878486844027b2766008ba80c0103b443f52cf9068a5c00f4e1ecf04106f4b29c11855822
-  languageName: node
-  linkType: hard
-
-"memoize-one@npm:^5.2.1":
-  version: 5.2.1
-  resolution: "memoize-one@npm:5.2.1"
-  checksum: a3cba7b824ebcf24cdfcd234aa7f86f3ad6394b8d9be4c96ff756dafb8b51c7f71320785fbc2304f1af48a0467cbbd2a409efc9333025700ed523f254cb52e3d
   languageName: node
   linkType: hard
 
@@ -15118,7 +14755,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mobx@npm:^6.3.2":
+"mobx@npm:^6.3.2, mobx@npm:^6.6.1":
   version: 6.6.1
   resolution: "mobx@npm:6.6.1"
   checksum: 20e876693d1a99916d347ba666f47e7931d5aa5a1172eae48d172477d537577d604207a8f8918041f9b6c74280b6533a516cf1639929735c6bb514f34776225a
@@ -15350,7 +14987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-addon-api@npm:^4.2.0, node-addon-api@npm:^4.3.0":
+"node-addon-api@npm:^4.3.0":
   version: 4.3.0
   resolution: "node-addon-api@npm:4.3.0"
   dependencies:
@@ -15509,7 +15146,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-object-hash@npm:^2.3.10, node-object-hash@npm:^2.3.9":
+"node-object-hash@npm:^2.3.10":
   version: 2.3.10
   resolution: "node-object-hash@npm:2.3.10"
   checksum: 5d2a80f67810294d352205bfc4823aa6097b06cd5dee6e0fec7e2bc40b55bfe5251e90313046230abe2fd230b8b7c5dcda967243e4136b94971e2630e6c7d0cd
@@ -15895,7 +15532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openapi-sampler@npm:^1.0.1, openapi-sampler@npm:^1.3.0":
+"openapi-sampler@npm:^1.3.0":
   version: 1.3.0
   resolution: "openapi-sampler@npm:1.3.0"
   dependencies:
@@ -16525,7 +16162,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"penpal@npm:^6.1.0":
+"penpal@npm:^6.2.2":
   version: 6.2.2
   resolution: "penpal@npm:6.2.2"
   checksum: f6e1ae44e12fce222486e24b3e4bacb25f2656a428c9d672c931d1b13a08aee9a90c4742b0422d6a14d55b6deebbfab01c7f5e994a4af8e876767e2fc65b0e32
@@ -17046,7 +16683,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.2.15, postcss@npm:^8.2.9, postcss@npm:^8.3.11, postcss@npm:^8.4.12":
+"postcss@npm:^8.2.15, postcss@npm:^8.2.9, postcss@npm:^8.3.11":
   version: 8.4.14
   resolution: "postcss@npm:8.4.14"
   dependencies:
@@ -17057,16 +16694,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"potrace@npm:^2.1.8":
-  version: 2.1.8
-  resolution: "potrace@npm:2.1.8"
+"postcss@npm:^8.4.14":
+  version: 8.4.16
+  resolution: "postcss@npm:8.4.16"
   dependencies:
-    jimp: ^0.14.0
-  checksum: 8b7168218058d7638cbced8bb9db2a87a754ec2e6b21b2332921b54c7124cfd5ee19db4bcb3faab9ead7994e4ca9e04012d5e4c67d8e4b300c2eb21b8b2b1c49
+    nanoid: ^3.3.4
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 10eee25efd77868036403858577da0cefaf2e0905feeaba5770d5438ccdddba3d01cba8063e96b8aac4c6daa0ed413dd5ae0554a433a3c4db38df1d134cffc1f
   languageName: node
   linkType: hard
 
-"preact-render-to-string@npm:^5.1.16":
+"preact-render-to-string@npm:^5.2.1":
   version: 5.2.1
   resolution: "preact-render-to-string@npm:5.2.1"
   dependencies:
@@ -17077,14 +16716,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"preact@npm:^10.5.12":
-  version: 10.10.0
-  resolution: "preact@npm:10.10.0"
-  checksum: ec34f0e7a8677080debb5e7035a749d30a23694a68389e6f577e051e91a1e1014913c56845a615d1f9a4f2cd0321c46faaded4d4a0457c755d637a3a811fd69e
+"preact@npm:^10.10.0":
+  version: 10.10.1
+  resolution: "preact@npm:10.10.1"
+  checksum: a79a196770064eb4d5a533e5b407f5eb842e47ea143bd4687e436ad3faf634efd4fda1185fab7b8c687a0889f1dea61349f1a01d6d6dfe1db3e0f4361f65c1d3
   languageName: node
   linkType: hard
 
-"prebuild-install@npm:^7.0.0, prebuild-install@npm:^7.1.1":
+"prebuild-install@npm:^7.1.1":
   version: 7.1.1
   resolution: "prebuild-install@npm:7.1.1"
   dependencies:
@@ -17151,16 +16790,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prism-react-renderer@npm:1.2.1":
-  version: 1.2.1
-  resolution: "prism-react-renderer@npm:1.2.1"
+"prism-react-renderer@npm:1.3.5":
+  version: 1.3.5
+  resolution: "prism-react-renderer@npm:1.3.5"
   peerDependencies:
     react: ">=0.14.9"
-  checksum: 66cab3d9f9f18ff5db222df74e1f326262ad093202f855ef2bd9e8001fef21b92f2242a2292caa77c36a517a7f379620417b421eaa320405deb6ecb27c18ee5e
+  checksum: c18806dcbc4c0b4fd6fd15bd06b4f7c0a6da98d93af235c3e970854994eb9b59e23315abb6cfc29e69da26d36709a47e25da85ab27fed81b6812f0a52caf6dfa
   languageName: node
   linkType: hard
 
-"prismjs@npm:^1.24.1, prismjs@npm:^1.27.0":
+"prismjs@npm:^1.27.0":
   version: 1.28.0
   resolution: "prismjs@npm:1.28.0"
   checksum: bde93fb2beb45b7243219fc53855f59ee54b3fa179f315e8f9d66244d756ef984462e10561bbdc6713d3d7e051852472d7c284f5794a8791eeaefea2fb910b16
@@ -17399,7 +17038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"query-string@npm:^6.13.3, query-string@npm:^6.13.8, query-string@npm:^6.14.1":
+"query-string@npm:^6.13.8, query-string@npm:^6.14.1":
   version: 6.14.1
   resolution: "query-string@npm:6.14.1"
   dependencies:
@@ -17590,7 +17229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-id-generator@npm:^3.0.1":
+"react-id-generator@npm:^3.0.2":
   version: 3.0.2
   resolution: "react-id-generator@npm:3.0.2"
   peerDependencies:
@@ -17725,9 +17364,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redoc-cli@npm:^0.13.0":
-  version: 0.13.16
-  resolution: "redoc-cli@npm:0.13.16"
+"redoc-cli@npm:^0.13.16":
+  version: 0.13.17
+  resolution: "redoc-cli@npm:0.13.17"
   dependencies:
     chokidar: ^3.5.1
     handlebars: ^4.7.7
@@ -17737,59 +17376,20 @@ __metadata:
     node-libs-browser: ^2.2.1
     react: ^17.0.1
     react-dom: ^17.0.1
-    redoc: 2.0.0-rc.72
+    redoc: 2.0.0-rc.74
     styled-components: ^5.3.0
     yargs: ^17.3.1
   bin:
     redoc-cli: index.js
-  checksum: 0787b4a47a403df63e99d39846d302dd1e52475f966a269d16b2fe922c419cf4b548c23622840d8e40e638ede48415204ba8197acb977cd4f4594e0afe40ca5f
+  checksum: a75c271f88ad027b65b10f47d26fab4f9d20d7070e477f0814e5b7b10c9a6f5c28b4a732449df4b9ad2b24faf1021628a6d958fa329079ec29637babaacb79cc
   languageName: node
   linkType: hard
 
-"redoc@npm:2.0.0-rc.56":
-  version: 2.0.0-rc.56
-  resolution: "redoc@npm:2.0.0-rc.56"
+"redoc@npm:2.0.0-rc.73":
+  version: 2.0.0-rc.73
+  resolution: "redoc@npm:2.0.0-rc.73"
   dependencies:
-    "@babel/runtime": ^7.14.0
-    "@redocly/openapi-core": ^1.0.0-beta.50
-    "@redocly/react-dropdown-aria": ^2.0.11
-    "@types/node": ^15.6.1
-    classnames: ^2.3.1
-    decko: ^1.2.0
-    dompurify: ^2.2.8
-    eventemitter3: ^4.0.7
-    json-pointer: ^0.6.1
-    lunr: ^2.3.9
-    mark.js: ^8.11.1
-    marked: ^0.7.0
-    memoize-one: ^5.2.1
-    mobx-react: ^7.2.0
-    openapi-sampler: ^1.0.1
-    path-browserify: ^1.0.1
-    perfect-scrollbar: ^1.5.1
-    polished: ^4.1.3
-    prismjs: ^1.24.1
-    prop-types: ^15.7.2
-    react-tabs: ^3.2.2
-    slugify: ~1.4.7
-    stickyfill: ^1.1.1
-    swagger2openapi: ^7.0.6
-    url-template: ^2.0.8
-  peerDependencies:
-    core-js: ^3.1.4
-    mobx: ^6.0.4
-    react: ^16.8.4 || ^17.0.0
-    react-dom: ^16.8.4 || ^17.0.0
-    styled-components: ^4.1.1 || ^5.1.1
-  checksum: dd04f7b4c3b85478f35a6ebb067eb2a4ce7d107040b716ec4044021d7ce3de1ab16620e1247381d867d9db9ee299a9e45fcd363f58d8094ecb8ba31ab86dc8df
-  languageName: node
-  linkType: hard
-
-"redoc@npm:2.0.0-rc.72":
-  version: 2.0.0-rc.72
-  resolution: "redoc@npm:2.0.0-rc.72"
-  dependencies:
-    "@redocly/openapi-core": ^1.0.0-beta.97
+    "@redocly/openapi-core": ^1.0.0-beta.104
     classnames: ^2.3.1
     decko: ^1.2.0
     dompurify: ^2.2.8
@@ -17817,7 +17417,43 @@ __metadata:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
     styled-components: ^4.1.1 || ^5.1.1
-  checksum: a7746149b302111311a13e96c83db188331794d77f854d583e27891b41b3d8433bc5a209e5609a4862cfc76ddc906211e2a2c53637dfd1143d6c0fb0e52880c1
+  checksum: ed4f0ee1d1cef9cf1e55bf4f1bac53cc9f0c77c8ad484d0f70d77fbf335ebcc5e8d1bbc6f760efbb56f16fa90d6d97f30addcc4d35c12f257d890ee37921160c
+  languageName: node
+  linkType: hard
+
+"redoc@npm:2.0.0-rc.74":
+  version: 2.0.0-rc.74
+  resolution: "redoc@npm:2.0.0-rc.74"
+  dependencies:
+    "@redocly/openapi-core": ^1.0.0-beta.104
+    classnames: ^2.3.1
+    decko: ^1.2.0
+    dompurify: ^2.2.8
+    eventemitter3: ^4.0.7
+    json-pointer: ^0.6.2
+    lunr: ^2.3.9
+    mark.js: ^8.11.1
+    marked: ^4.0.15
+    mobx-react: ^7.2.0
+    openapi-sampler: ^1.3.0
+    path-browserify: ^1.0.1
+    perfect-scrollbar: ^1.5.1
+    polished: ^4.1.3
+    prismjs: ^1.27.0
+    prop-types: ^15.7.2
+    react-tabs: ^3.2.2
+    slugify: ~1.4.7
+    stickyfill: ^1.1.1
+    style-loader: ^3.3.1
+    swagger2openapi: ^7.0.6
+    url-template: ^2.0.8
+  peerDependencies:
+    core-js: ^3.1.4
+    mobx: ^6.0.4
+    react: ^16.8.4 || ^17.0.0
+    react-dom: ^16.8.4 || ^17.0.0
+    styled-components: ^4.1.1 || ^5.1.1
+  checksum: 11f03ff024a9c12a059205bd5ad2c43ef6866ed3d4312815422630dc174437fa8ade7f39a40d9337237e01161419676739ac0050cf593e0a05e86dcff8390a7f
   languageName: node
   linkType: hard
 
@@ -17943,19 +17579,6 @@ __metadata:
   bin:
     regjsparser: bin/parser
   checksum: d069b932491761cda127ce11f6bd2729c3b1b394a35200ec33f1199e937423db28ceb86cf33f0a97c76ecd7c0f8db996476579eaf0d80a1f74c1934f4ca8b27a
-  languageName: node
-  linkType: hard
-
-"rehype-slug@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "rehype-slug@npm:4.0.1"
-  dependencies:
-    github-slugger: ^1.1.1
-    hast-util-has-property: ^1.0.0
-    hast-util-heading-rank: ^1.0.0
-    hast-util-to-string: ^1.0.0
-    unist-util-visit: ^2.0.0
-  checksum: 9e4851378dbbcf1359f4e300c9d685e6693688e4028e50a84d33cef56d53eccffd2fe2f140102e2fb55a59f4ae1b903a47199dfb52179438c9d4a7e74d8e75f7
   languageName: node
   linkType: hard
 
@@ -18803,24 +18426,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sharp@npm:^0.29.0":
-  version: 0.29.3
-  resolution: "sharp@npm:0.29.3"
-  dependencies:
-    color: ^4.0.1
-    detect-libc: ^1.0.3
-    node-addon-api: ^4.2.0
-    node-gyp: latest
-    prebuild-install: ^7.0.0
-    semver: ^7.3.5
-    simple-get: ^4.0.0
-    tar-fs: ^2.1.1
-    tunnel-agent: ^0.6.0
-  checksum: d496cdd546c9abe743aebcee013731295f735687819a18c2bdcbba6f31a6b259f3da95af5c11260a8fedc9d4ab95697f5f8c4f3cd65232792b5cfb876bea7c9a
-  languageName: node
-  linkType: hard
-
-"sharp@npm:^0.30.3":
+"sharp@npm:^0.30.3, sharp@npm:^0.30.7":
   version: 0.30.7
   resolution: "sharp@npm:0.30.7"
   dependencies:
@@ -19357,7 +18963,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stream-http@npm:^3.1.1":
+"stream-http@npm:^3.2.0":
   version: 3.2.0
   resolution: "stream-http@npm:3.2.0"
   dependencies:
@@ -19654,7 +19260,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"styled-components@npm:^5.3.0, styled-components@npm:^5.3.1":
+"styled-components@npm:^5.3.0, styled-components@npm:^5.3.5":
   version: 5.3.5
   resolution: "styled-components@npm:5.3.5"
   dependencies:
@@ -19840,13 +19446,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swiper@npm:^7.0.6":
-  version: 7.4.1
-  resolution: "swiper@npm:7.4.1"
+"swiper@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "swiper@npm:8.3.2"
   dependencies:
-    dom7: ^4.0.2
+    dom7: ^4.0.4
     ssr-window: ^4.0.2
-  checksum: 996339afa86a0200564d2418b9f5a5f222cb91a5fec7a1ee3123e47a8978b7458fedeb87c7dfeb86ad0559c2bef3e20779a87d71987e9d36b5651fa9dada9a2c
+  checksum: 881d8e4fdedc391593c9ecee1ca0fddaebd16b2f6be493f80869fbaf848761cf7e41a7d7ba4b9fe4c4d61e9bef87ba33154d22bb6a8a8503c22c49f793bef1c1
   languageName: node
   linkType: hard
 
@@ -20764,28 +20370,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unist-util-select@npm:2.0.0":
-  version: 2.0.0
-  resolution: "unist-util-select@npm:2.0.0"
+"unist-util-select@npm:2.0.2":
+  version: 2.0.2
+  resolution: "unist-util-select@npm:2.0.2"
   dependencies:
     css-selector-parser: ^1.1.0
-    debug: ^3.1.0
     not: ^0.1.0
     nth-check: ^1.0.1
-    unist-util-is: ^2.1.2
+    unist-util-is: ^3.0.0
     zwitch: ^1.0.3
-  checksum: b93682a4a00327ecc0f465886377ccb2e339e0088f2bfd06052627f295f848ce43f3d963e9241266984cdddef5ae61c39b5e66e6ec93d0cce5c6f12d0df686a0
-  languageName: node
-  linkType: hard
-
-"unist-util-select@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "unist-util-select@npm:1.5.0"
-  dependencies:
-    css-selector-parser: ^1.1.0
-    debug: ^2.2.0
-    nth-check: ^1.0.1
-  checksum: 19681874146213fc151d3faecfbb2999bbc63722b0e3cda06e769dd153f128d9bfc9350aa574878a64e322fb5de8179a87fb32ff71f0262838ef8361ac8c540c
+  checksum: 5f356bfa4e8fca4b3805768ca4a2e425c7d2a8c664c25fbf7d4d1e7108ecd6b4ed358bf599135164a3ed901c7fa8607bb312ef3778b2e370bc5e61617bed3cdc
   languageName: node
   linkType: hard
 
@@ -20834,7 +20428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unist-util-visit-parents@npm:^2.0.0, unist-util-visit-parents@npm:^2.1.2":
+"unist-util-visit-parents@npm:^2.0.0":
   version: 2.1.2
   resolution: "unist-util-visit-parents@npm:2.1.2"
   dependencies:
@@ -20843,7 +20437,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unist-util-visit-parents@npm:^3.0.0":
+"unist-util-visit-parents@npm:^3.0.0, unist-util-visit-parents@npm:^3.1.1":
   version: 3.1.1
   resolution: "unist-util-visit-parents@npm:3.1.1"
   dependencies:
@@ -20874,7 +20468,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unist-util-visit@npm:^1.0.0, unist-util-visit@npm:^1.1.0, unist-util-visit@npm:^1.4.1":
+"unist-util-visit@npm:^1.1.0, unist-util-visit@npm:^1.4.1":
   version: 1.4.1
   resolution: "unist-util-visit@npm:1.4.1"
   dependencies:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) bumps the theme to the latest version (4.4.2). We suspect it's the reason why the site search icon is not displaying.

## Affected pages

- n/a

## Links to related PRs or Jira tickets

- n/a

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My changes follow the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
