### PR TITLE
Replace obsolete devdocs links

### DIFF
--- a/src/pages/guide/caching.md
+++ b/src/pages/guide/caching.md
@@ -14,11 +14,11 @@ Retrieving stored ([cached](https://glossary.magento.com/cache)) content from a 
 
 The Adobe Commerce and Magento Open Source page cache library contains a simple PHP reverse proxy that enables full page caching out of the box. A reverse proxy acts as an intermediary between visitors and your application and can reduce the load on your server.
 
-We recommend using [Varnish](https://devdocs.magento.com/guides/v2.4/config-guide/varnish/config-varnish.html), but you can use the default caching mechanism instead, which stores cache files in any of the following:
+We recommend using [Varnish](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cache/varnish/config-varnish.html), but you can use the default caching mechanism instead, which stores cache files in any of the following:
 
 -  File system (You don't need to do anything to use file-based caching.)
 -  [Database](https://developer.adobe.com/commerce/php/development/cache/partial/database-caching/)
--  [Redis](https://devdocs.magento.com/guides/v2.4/config-guide/redis/redis-pg-cache.html)
+-  [Redis](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cache/redis/redis-pg-cache.html)
 
 ## Cacheable and uncacheable pages
 
@@ -65,7 +65,7 @@ The following cache types mostly have impact on frontend development process:
 
 <InlineAlert variant="help" slots="text"/>
 
-The full list of cache types can be found in the [Overview of cache types](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-cache.html#config-cli-subcommands-cache-clean-over) topic.
+The full list of cache types can be found in the [Overview of cache types](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/manage-cache.html) topic.
 
 ## Clean cache
 
@@ -81,7 +81,7 @@ To view the status of the cache, run:
 bin/magento cache:status
 ```
 
-For more details about working with cache, see [Manage the cache](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-cache.html)
+For more details about working with cache, see [Manage the cache](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/manage-cache.html)
 
 ## Clean static files cache
 
@@ -90,7 +90,7 @@ You can clean generated static view files in any of the following ways:
 -  In the [Admin](https://glossary.magento.com/magento-admin). Go to **System** > **Tools** > **Cache Management** and click **Flush [Static Files](https://glossary.magento.com/static-files) Cache**.
 
     {:.bs-callout-info}
-   This option is only available in `developer` mode. Refer to the [static view files overview](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-static-view.html#config-cli-static-overview) for more information. For more details about the application modes, see [application modes](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html)
+   This option is only available in `developer` mode. Refer to the [static view files overview](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/static-view/static-view-file-deployment.html) for more information. For more details about the application modes, see [application modes](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/set-mode.html)
 
 -  Manually by clearing the `pub/static` and `var/view_preprocessed` directories and subdirectories *except* for `pub/static/.htaccess`.
 

--- a/src/pages/guide/css/critical-path.md
+++ b/src/pages/guide/css/critical-path.md
@@ -13,7 +13,7 @@ Thus we can significantly improve the time to first render of our pages.
 
 <InlineAlert variant="info" slots="text"/>
 
-CSS critical path configuration is located on the **Stores** > Settings > **Configuration** > **ADVANCED** > **Developer** tab. However, the **Developer** tab is hidden in [production mode](https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html). Once in production mode, CSS critical path can only be enabled using the CLI.
+CSS critical path configuration is located on the **Stores** > Settings > **Configuration** > **ADVANCED** > **Developer** tab. However, the **Developer** tab is hidden in [production mode](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html). Once in production mode, CSS critical path can only be enabled using the CLI.
 
 To enable the CSS critical path:
 

--- a/src/pages/guide/css/debug.md
+++ b/src/pages/guide/css/debug.md
@@ -9,7 +9,7 @@ The topic describes how to install, configure, and use [Grunt JavaScript task ru
 
 ## Prerequisites
 
--  Make sure that you [set](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html) your application to the developer or default [mode](https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html). The default mode sets the Less compilation mode to Server-side Less compilation.
+-  Make sure that you [set](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/set-mode.html) your application to the developer or default [mode](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html). The default mode sets the Less compilation mode to Server-side Less compilation.
 -  Install and configure [Grunt](../tools/grunt.md).
 
 ## Add themes to Grunt configuration

--- a/src/pages/guide/css/index.md
+++ b/src/pages/guide/css/index.md
@@ -18,7 +18,7 @@ To customize [storefront](https://glossary.magento.com/storefront) styles, you n
 
 ## Things to remember when working with styles
 
-*  Make sure that you [set](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html) your application to the developer or default [mode](https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html).
+*  Make sure that you [set](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/set-mode.html) your application to the developer or default [mode](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html).
 
 *  If your style changes do not apply after refreshing the page, cleaning the static files cache might help. See the [caching](../caching.md#page-caching) for instructions how to do this.
 

--- a/src/pages/guide/css/preprocess.md
+++ b/src/pages/guide/css/preprocess.md
@@ -68,7 +68,7 @@ In server-side Less compilation mode, to have your changes applied, you need to 
 1. Trigger [static files](https://glossary.magento.com/static-files) compilation and publication. This can be done in one of the following ways:
 
    -  Reloading the page where the modified styles are applied.
-   -  Running the [static files deployment tool](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-static-view.html).
+   -  Running the [static files deployment tool](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/static-view/static-view-file-deployment.html).
 
 Reloading the page only triggers compilation and publication of the styles used on this very page, and does not give you the information about the errors if any. So if you made changes in `.less` files used on many pages, and want to debug them, using the deployment tool is the better option.
 
@@ -96,7 +96,7 @@ The tool pre-processes (including compilation) and publishes the static view fil
 
 <InlineAlert variant="info" slots="text"/>
 
-Manual static content deployment is not required in "default" and "developer" modes. If you still want to deploy in these modes, use the -f option: `bin/magento setup:static-content:deploy -f`. Read more about the command in the [Deploy static view files](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-static-view.html) section.
+Manual static content deployment is not required in "default" and "developer" modes. If you still want to deploy in these modes, use the -f option: `bin/magento setup:static-content:deploy -f`. Read more about the command in the [Deploy static view files](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/static-view/static-view-file-deployment.html) section.
 
 All errors occurring during `.less` files compilation are handled by the [LESS PHP library][] third party library.
 
@@ -260,9 +260,9 @@ In the processed file, this results in the following:
 ```
 
 <!-- Link definitions -->
-[production application mode]: https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html#production-mode
+[production application mode]:https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html#production-mode
 [LESS PHP library]: https://github.com/wikimedia/less.php
 [native `less.js` library]: http://lesscss.org/usage/#using-less-in-the-browser
 [fallback mechanism]: ../themes/inheritance.md#override-static-assets
-[publication]: https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-static-view.html#config-cli-static-overview
+[publication]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/static-view/static-view-file-deployment.html
 [static files fallback]: ../themes/inheritance.md#override-static-assets

--- a/src/pages/guide/css/quickstart/index.md
+++ b/src/pages/guide/css/quickstart/index.md
@@ -39,12 +39,10 @@ Making changes in the out-of-the-box themes is a bad idea, because can result in
 <!-- Link Definitions -->
 [Simple ways to customize a theme's styles]: customize-styles.md
 [Simple style changes with client-side Less compilation vs. server-side]: compilation-mode.md
-[Set]: https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html
-[mode]: https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html
+[Set]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/set-mode.html
+[mode]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html
 [add a new theme]: ../../themes/create-storefront.md
-
 [Apply your theme]: ../../themes/apply-storefront.md
-
 [Styles debugging]: ../debug.md
 [Simple style changes with client-side Less compilation vs. server-side]: compilation-mode.md
 [css overview]: ../index.md

--- a/src/pages/guide/layouts/index.md
+++ b/src/pages/guide/layouts/index.md
@@ -111,7 +111,7 @@ Layout validations and error handling depends on the [application mode] in which
 [override]: override.md
 [Layout file types]: types.md
 [inherited]: ../themes/inheritance.md
-[application mode]: https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html
+[application mode]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html
 [Layout instructions]: xml-instructions.md
 
 <!-- Image Definitions -->

--- a/src/pages/guide/templates/email-migration.md
+++ b/src/pages/guide/templates/email-migration.md
@@ -20,7 +20,7 @@ The following command scans all database email templates overridden using the Ad
 bin/magento dev:email:override-compatibility-check
 ```
 
-To scan email templates overriden using a custom [theme](https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/templates/template-email.html#customize-email-theme), please consider using the [Upgrade Compatibility Tool](https://experienceleague.adobe.com/docs/commerce-operations/upgrade-guide/upgrade-compatibility-tool/install.html).
+To scan email templates overriden using a custom [theme](email.md), please consider using the [Upgrade Compatibility Tool](https://experienceleague.adobe.com/docs/commerce-operations/upgrade-guide/upgrade-compatibility-tool/install.html).
 
 The following command scans newsletter templates for any potential variable usage compatibility issues.
 

--- a/src/pages/guide/templates/walkthrough.md
+++ b/src/pages/guide/templates/walkthrough.md
@@ -9,7 +9,7 @@ This topic walks you through how to customize a template.
 
 ## Prerequisites
 
-[Set](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html) your application to the developer [mode](https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html). The application mode influences the way [static files](https://glossary.magento.com/static-files) are cached by the application. The recommendations about [theme](https://glossary.magento.com/theme) development we provide in this chapter are developer/default-mode specific.
+[Set](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/set-mode.html) your application to the developer [mode](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html). The application mode influences the way [static files](https://glossary.magento.com/static-files) are cached by the application. The recommendations about [theme](https://glossary.magento.com/theme) development we provide in this chapter are developer/default-mode specific.
 
 ## Template customization walkthrough
 

--- a/src/pages/guide/themes/apply-admin.md
+++ b/src/pages/guide/themes/apply-admin.md
@@ -9,7 +9,7 @@ This topic describes how to apply your custom [theme](https://glossary.magento.c
 
 ## Prerequisites
 
-1. [Set](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html) your application to the developer [mode](https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html). The application mode influences the way [static files](https://glossary.magento.com/static-files) are cached.
+1. [Set](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/set-mode.html) your application to the developer [mode](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html). The application mode influences the way [static files](https://glossary.magento.com/static-files) are cached.
 1. [Create a custom theme for the Admin panel](../themes/create-admin.md).
 1. [Add a new custom module](https://developer.adobe.com/commerce/php/development/build/) or decide to use existing custom module. The module must load after the Magento_Theme module. To ensure this, add the following code in `<your_custom_module_dir>/etc/module.xml` (replace placeholders with your [module](https://glossary.magento.com/module) information):
 
@@ -66,7 +66,7 @@ run the `bin/magento setup:upgrade` command in your command line. If prompted, a
 
 For details about performing command line tasks, view the following topics:
 
--  [Command line configuration](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli.html)
+-  [Command line configuration](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/config-cli.html)
 -  [Uninstall or reinstall the application: Optionally keeping generated files](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-subcommands-db-upgr.html)
 
 ## Open Admin in browser

--- a/src/pages/guide/themes/apply-storefront.md
+++ b/src/pages/guide/themes/apply-storefront.md
@@ -10,7 +10,7 @@ Also, it gives information how to add a theme independent logo for your store.
 
 ## Prerequisites
 
-Make sure that you [set](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html) your application to the developer [mode](https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html).
+Make sure that you [set](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/set-mode.html) your application to the developer [mode](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html).
 
 ## Apply a theme
 

--- a/src/pages/guide/themes/create-admin.md
+++ b/src/pages/guide/themes/create-admin.md
@@ -8,7 +8,7 @@ This topic describes how to create your custom theme for Admin, referencing the 
 
 ## Prerequisites
 
-[Set](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html) your application to the developer [mode](https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html). The application mode influences the way [static files](https://glossary.magento.com/static-files) are cached.
+[Set](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/set-mode.html) your application to the developer [mode](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html). The application mode influences the way [static files](https://glossary.magento.com/static-files) are cached.
 
 ## Overview
 

--- a/src/pages/guide/themes/create-storefront.md
+++ b/src/pages/guide/themes/create-storefront.md
@@ -14,7 +14,7 @@ A new theme you create is not applied for your store automatically. You need to 
 ## Prerequisites
 
 1. For the sake of compatibility, upgradability, and easy maintenance, do not modify the out-of-the-box themes. To customize the design of your store, create a new custom [theme](https://glossary.magento.com/theme).
-1. [Set](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html) your application to the developer [mode](https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html). The application mode influences the way [static files](https://glossary.magento.com/static-files) are cached. The recommendations about theme development we provide in this chapter are developer/default-mode specific.
+1. [Set](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/set-mode.html) your application to the developer [mode](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html). The application mode influences the way [static files](https://glossary.magento.com/static-files) are cached. The recommendations about theme development we provide in this chapter are developer/default-mode specific.
 
 ## Walkthrough
 
@@ -30,7 +30,7 @@ The high-level steps required to add a new theme in the system are the following
 ## Recommended reading
 
 *  [Checklist of modules](https://github.com/magento/magento2/blob/2.4/app/code/Magento)
-*  [Static view files processing](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-static-view.html)
+*  [Static view files processing](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/static-view/static-view-file-deployment.html)
 
 ## Create a theme directory
 

--- a/src/pages/guide/themes/install.md
+++ b/src/pages/guide/themes/install.md
@@ -16,7 +16,7 @@ The following sections contain more information about each installation flow.
 
 ## Prerequisites
 
-[Set](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html) your application to the developer or default [mode](https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html).
+[Set](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/set-mode.html) your application to the developer or default [mode](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html).
 
 ## Manual install
 

--- a/src/pages/guide/themes/js-bundling.md
+++ b/src/pages/guide/themes/js-bundling.md
@@ -153,7 +153,7 @@ Follow these steps to help you identify which JavaScript files to bundle for you
 1. Compare the JavaScript files loaded in the pages with the JavaScript files.
 1. Use the results of that comparison to build your exclude list.
 
-[production-mode]:https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html#production-mode
-[static-content]:https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-static-view.html
+[production-mode]:https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html#production-mode
+[static-content]:https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/static-view/static-view-file-deployment.html
 [Advanced-JavaScript-Bundling]:https://experienceleague.adobe.com/docs/commerce-operations/performance-best-practices/performance-best-practices/advanced-js-bundling.html
 [luma-view-xml]:https://github.com/magento/magento2/blob/2.4/app/design/frontend/Magento/luma/etc/view.xml#L270

--- a/src/pages/guide/themes/structure.md
+++ b/src/pages/guide/themes/structure.md
@@ -104,7 +104,7 @@ Static view files that can be accessed by a direct link from the storefront, are
 
 <InlineAlert variant="info" slots="text"/>
 
-To be actually accessible for browsers public static files are [published](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-static-view.html#config-cli-static-overview) to the `/pub/static/frontend/<Vendor>/<theme>/<locale>/css/` directory.
+To be actually accessible for browsers public static files are [published](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/static-view/static-view-file-deployment.html#config-cli-static-overview) to the `/pub/static/frontend/<Vendor>/<theme>/<locale>/css/` directory.
 
 ### Dynamic view files
 

--- a/src/pages/guide/themes/uninstall.md
+++ b/src/pages/guide/themes/uninstall.md
@@ -16,7 +16,7 @@ The following sections describe the flow for uninstalling themes in each case.
 
 ## Prerequisites
 
-1. [Set your application to the developer or default mode](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html).
+1. [Set your application to the developer or default mode](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/set-mode.html).
 1. Make sure that the theme is not applied on the storefront. To do this, in the [Admin](https://glossary.magento.com/admin) panel navigate to **Content** > Design > **Configuration** and make sure that your custom theme is not applied for any [store view](https://glossary.magento.com/store-view).
 1. Make sure that the theme is not defined as a parent for any registered theme. To do this, in the Admin panel, navigate to **Content** > Design > **Themes**. Make sure that your theme is not mentioned in the **Parent Theme** column. If it is mentioned, you need to uninstall the child theme first.
 

--- a/src/pages/guide/themes/workflow.md
+++ b/src/pages/guide/themes/workflow.md
@@ -15,8 +15,8 @@ bin/magento deploy:mode:set developer
 
 See:
 
-*  [About application modes](https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html)
-*  [Get started with command-line configuration](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands.html)
+*  [About application modes](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html)
+*  [Get started with command-line configuration](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/config-cli.html)
 
 <InlineAlert variant="success" slots="text"/>
 
@@ -94,8 +94,8 @@ In the installation directory, run:
 bin/magento deploy:mode:set production
 ```
 
-See [application modes](https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html#production-mode) for details.
+See [application modes](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html#production-mode) for details.
 
 ### Deploy static content
 
-To publish your static files to the `pub/static` directory when your instance is set to production mode, [run the static content deployment tool](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-static-view.html).
+To publish your static files to the `pub/static` directory when your instance is set to production mode, [run the static content deployment tool](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/static-view/static-view-file-deployment.html).

--- a/src/pages/guide/tools/grunt.md
+++ b/src/pages/guide/tools/grunt.md
@@ -11,7 +11,7 @@ You can use Grunt to automate any tasks you need, but out of the box the applica
 
 ## Prerequisites
 
-Make sure that you [set](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html) your application to the developer or default [mode](https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/magento-modes.html).
+Make sure that you [set](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/set-mode.html) your application to the developer or default [mode](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/setup/application-modes.html).
 
 ## Install and configure Grunt
 

--- a/src/pages/guide/translations/dictionary.md
+++ b/src/pages/guide/translations/dictionary.md
@@ -66,6 +66,6 @@ The locale dictionary would use the default values (keys) in the left column fol
 
 [translation dictionaries]: index.md#terms
 [`<Magento_Luma_theme_dir>/i18n/en_US.csv`]: https://github.com/magento/magento2/blob/2.4/app/design/frontend/Magento/luma/i18n/en_US.csv
-[i18n tool]: https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-dict
-[Generate the dictionary]: https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-dict
+[i18n tool]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/localization.html
+[Generate the dictionary]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/localization.html
 [Example theme translation dictionary]: practice.md

--- a/src/pages/guide/translations/index.md
+++ b/src/pages/guide/translations/index.md
@@ -145,7 +145,7 @@ In addition to the `.csv` file that contains the language dictionary, the langua
 *  `composer.json` that contains any dependencies for the language package and a mapping to its defined [locale](https://glossary.magento.com/locale). [Sample composer.json](https://developer.adobe.com/commerce/php/development/package/component/#sample-composerjson-file).
 
 *  `language.xml`, in which you declare a language package.
-   [Sample language.xml](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-example2).
+   [Sample language.xml](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/localization.html#example%3A-create-a-language-package).
 
 ## Open-source translations project
 
@@ -160,14 +160,14 @@ Admins will review and approve translations as available. The project may includ
 
 If you need help understanding the context or meaning of a UI string, or have questions about the project, chat with us in the Community Engineering [Translations Slack channel]. To join, send a request to [engcom@magento.com] or [self signup].
 
-[Generate a translation dictionary]: https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-dict
-[language inheritance]: https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-i18n.html#m2devgde-xlate-inheritancework
+[Generate a translation dictionary]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/localization.html
+[language inheritance]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/localization.html#create-directories-and-files
 [parent theme]: ../themes/inheritance.md
 [Example theme translation dictionary]: practice.md
-[translation dictionary tool]: https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-dict
-[language package]: https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-pack
-[dictionary generator tool]: https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-dict
-[Translation dictionaries and packages]: https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-i18n.html
+[translation dictionary tool]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/localization.html
+[language package]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/localization.html#create-a-language-package
+[dictionary generator tool]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/localization.html
+[Translation dictionaries and packages]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/localization.html
 [CrowdIn account]: https://crowdin.com/join
 [CrowdIn knowledge base]: https://support.crowdin.com/online-editor
 [engcom@magento.com]: mailto:engcom@magento.com

--- a/src/pages/guide/translations/practice.md
+++ b/src/pages/guide/translations/practice.md
@@ -23,7 +23,7 @@ The following image shows a page where the current strings are used:
 
 To override the strings, ExampleCorp plans to use the `en_US.csv` dictionary file.
 
-1. Run the [i18n (internationalization) tool](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-dict) to generate the en_US dictionary for the `orange` theme:
+1. Run the [i18n (internationalization) tool](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/localization.html) to generate the en_US dictionary for the `orange` theme:
 
    ```bash
    bin/magento i18n:collect-phrases --output="app/design/frontend/ExampleCorp/orange/i18n/en_US.csv" app/design/frontend/ExampleCorp/orange

--- a/src/pages/guide/translations/theory.md
+++ b/src/pages/guide/translations/theory.md
@@ -152,8 +152,8 @@ To ensure that the text you add in a `.js` file is collected by the i18n tool an
 
 In this example, the `'Hello %1'` string is added to the dictionary when the i18n tool is run.
 
-[i18n tool]: https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-i18n.html
-[generating the dictionary]: https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-i18n.html#config-cli-subcommands-xlate-dict
+[i18n tool]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/localization.html
+[generating the dictionary]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/localization.html
 [.phtml template]: ../templates/index.md
 [custom email templates]: ../templates/email.md
 [directive]: ../templates/email.md#localization

--- a/src/pages/javascript/frontend-product-repository.md
+++ b/src/pages/javascript/frontend-product-repository.md
@@ -188,7 +188,7 @@ The object structure for this REST response is represented by [`\Magento\Catalog
 ]
 ```
 
-[datasource-component]: https://devdocs.magento.com/guides/v2.4/ui_comp_guide/concepts/ui_comp_data_source.html
+[datasource-component]: https://developer.adobe.com/commerce/frontend-core/ui-components/concepts/data-source/
 [recently-viewed-widget]: https://github.com/magento/magento2/blob/2.4/app/code/Magento/Catalog/view/frontend/ui_component/widget_recently_viewed.xml
 [product-render-interface]: https://github.com/magento/magento2/blob/2.4/app/code/Magento/Catalog/Api/Data/ProductRenderInterface.php
 [storage-service]: https://github.com/magento/magento2/blob/2.4/app/code/Magento/Catalog/view/frontend/web/js/product/storage/storage-service.js

--- a/src/pages/javascript/index.md
+++ b/src/pages/javascript/index.md
@@ -44,4 +44,4 @@ JavaScript automatic testing is described in a separate [JavaScript unit testing
 [Locate JavaScript]: debug.md
 [jQuery widgets]: jquery-widgets/index.md
 [Customizing JavaScript illustration]: practice.md
-[JavaScript unit testing]: https://devdocs.magento.com/guides/v2.4/test/js/jasmine.html
+[JavaScript unit testing]: https://developer.adobe.com/commerce/testing/guide/js/

--- a/src/pages/javascript/jquery-widgets/alert.md
+++ b/src/pages/javascript/jquery-widgets/alert.md
@@ -243,6 +243,6 @@ require([
 [confirmation widget]: confirm.md
 [modal widget]: modal.md
 [`<Magento_Ui_module_dir>/view/base/web/js/modal/alert.js`]: https://github.com/magento/magento2/blob/2.4/app/code/Magento/Ui/view/base/web/js/modal/alert.js
-[Admin Pattern Library, the Slide-out Panels, Modal Windows, and Overlays topic.]: https://devdocs.magento.com/guides/v2.4/pattern-library/containers/slideouts-modals-overlays/slideouts-modals-overalys.html#modals
+[Admin Pattern Library, the Slide-out Panels, Modal Windows, and Overlays topic.]: https://developer.adobe.com/commerce/admin-developer/pattern-library/containers/slideouts-modals-overlays/#modals
 [JavaScript initialization]: ../init.md
 [navigation of the modal widget]: modal.md#keyboard-navigation

--- a/src/pages/javascript/jquery-widgets/confirm.md
+++ b/src/pages/javascript/jquery-widgets/confirm.md
@@ -260,6 +260,6 @@ require([
 ![Confirmation Widget](../../_images/javascript/confirm-widget-result.png)
 [modal widget]: modal.md
 [`<Magento_Ui_module_dir>/view/base/web/js/modal/confirm.js`]: https://github.com/magento/magento2/blob/2.4/app/code/Magento/Ui/view/base/web/js/modal/confirm.js
-[Admin Pattern Library, the Slide-out Panels, Modal Windows, and Overlays topic.]: https://devdocs.magento.com/guides/v2.4/pattern-library/containers/slideouts-modals-overlays/slideouts-modals-overalys.html#modals
+[Admin Pattern Library, the Slide-out Panels, Modal Windows, and Overlays topic.]: https://developer.adobe.com/commerce/admin-developer/pattern-library/containers/slideouts-modals-overlays/#modals
 [JavaScript initialization]: ../init.md
 [navigation of the modal widget]: modal.md#keyboard-navigation

--- a/src/pages/javascript/jquery-widgets/list.md
+++ b/src/pages/javascript/jquery-widgets/list.md
@@ -7,7 +7,7 @@ description: Learn how to initialize and configure the Adobe Commerce and Magent
 
 <InlineAlert variant="warning" slots="text" />
 
-The list widget is deprecated since version 2.2.0. As an alternative component for the admin area, use [DynamicRows](https://devdocs.magento.com/guides/v2.4/ui_comp_guide/components/ui-dynamicrows.html).
+The list widget is deprecated since version 2.2.0. As an alternative component for the admin area, use [DynamicRows](https://developer.adobe.com/commerce/frontend-core/ui-components/components/dynamic-rows/).
 
 Provides a way to move items, typically a list, from one content section to another.
 The content can be moved using buttons and links.

--- a/src/pages/javascript/jquery-widgets/modal.md
+++ b/src/pages/javascript/jquery-widgets/modal.md
@@ -401,5 +401,5 @@ The result is a modal and a button (_Click Here_) that opens the modal.
 [`<Magento_Ui_module_dir>/view/base/web/js/modal/modal.js`]: https://github.com/magento/magento2/blob/2.4/app/code/Magento/Ui/view/base/web/js/modal/modal.js
 [`<Magento_Ui_module_dir>/view/base/web/templates/modal/modal-popup.html`]: https://github.com/magento/magento2/blob/2.4/app/code/Magento/Ui/view/base/web/templates/modal/modal-popup.html
 [`<Magento_Ui_module_dir>/view/base/web/templates/modal/modal-slide.html`]: https://github.com/magento/magento2/blob/2.4/app/code/Magento/Ui/view/base/web/templates/modal/modal-slide.html
-[Admin Pattern Library, the Slide-out Panels, Modal Windows, and Overlays topic.]: https://devdocs.magento.com/guides/v2.4/pattern-library/containers/slideouts-modals-overlays/slideouts-modals-overalys.html#modals
+[Admin Pattern Library, the Slide-out Panels, Modal Windows, and Overlays topic.]: https://developer.adobe.com/commerce/admin-developer/pattern-library/containers/slideouts-modals-overlays/#modals
 [JavaScript initialization]: ../init.md

--- a/src/pages/javascript/jquery-widgets/prompt.md
+++ b/src/pages/javascript/jquery-widgets/prompt.md
@@ -306,5 +306,5 @@ The prompt widget implements the following events:
 [modal widget]: modal.md
 [`<Magento_Ui_module_dir>/view/base/web/js/modal/prompt.js`]: https://github.com/magento/magento2/blob/2.4/app/code/Magento/Ui/view/base/web/js/modal/prompt.js
 [`ui/template/modal/modal-prompt-content.html`]: https://github.com/magento/magento2/blob/2.4/app/code/Magento/Ui/view/base/web/templates/modal/modal-prompt-content.html
-[Admin Pattern Library, the Slide-out Panels, Modal Windows, and Overlays topic.]: https://devdocs.magento.com/guides/v2.4/pattern-library/containers/slideouts-modals-overlays/slideouts-modals-overalys.html#modals
+[Admin Pattern Library, the Slide-out Panels, Modal Windows, and Overlays topic.]: https://developer.adobe.com/commerce/admin-developer/pattern-library/containers/slideouts-modals-overlays/#modals
 [JavaScript initialization]: ../init.md

--- a/src/pages/ui-components/components/filters.md
+++ b/src/pages/ui-components/components/filters.md
@@ -7,7 +7,7 @@ description: Configure Adobe Commerce and Magento Open Source UI components and 
 
 The Filters component renders UI controls for filtering and applies filtering. Must be a child of the [Listing component](listing-grid.md).
 
-See the [Admin Design Pattern Library (Filters)](https://devdocs.magento.com/guides/v2.4/pattern-library/filters/data-table-filters/filtering.html) topic for information about the UI design patterns that can be implemented using Filters component.
+See the [Admin Design Pattern Library (Filters)](https://developer.adobe.com/commerce/admin-developer/pattern-library/displaying-data/filters/) topic for information about the UI design patterns that can be implemented using Filters component.
 
 ## Options
 

--- a/src/pages/ui-components/components/mass-actions.md
+++ b/src/pages/ui-components/components/mass-actions.md
@@ -7,7 +7,7 @@ description: Configure Adobe Commerce and Magento Open Source UI components and 
 
 The MassActions component allows performing actions with multiple selected items. Must be a child of the [Listing component](listing-grid.md).
 
-See the [Admin Design Pattern Library (MassActions)](https://devdocs.magento.com/guides/v2.4/pattern-library/displaying-data/datatable/datatable.html#mass-actions) topic for information about the UI design patterns that can be implemented using the MassActions component.
+See the [Admin Design Pattern Library (MassActions)](https://developer.adobe.com/commerce/admin-developer/pattern-library/displaying-data/datatable/#mass-actions) topic for information about the UI design patterns that can be implemented using the MassActions component.
 
 ## Dependencies
 

--- a/src/pages/ui-components/components/modal.md
+++ b/src/pages/ui-components/components/modal.md
@@ -11,7 +11,7 @@ Similar to the widget's configuration, the component's configuration allows you 
 
 The Modal component can be used for both [Admin](https://glossary.magento.com/admin) and storefronts.
 
-For recommendations about modal windows usage from the UX point of view, see the corresponding topic in the [Admin pattern library](https://devdocs.magento.com/guides/v2.4/pattern-library/containers/slideouts-modals-overlays/slideouts-modals-overalys.html).
+For recommendations about modal windows usage from the UX point of view, see the corresponding topic in the [Admin pattern library](https://developer.adobe.com/commerce/admin-developer/pattern-library/containers/slideouts-modals-overlays/).
 
 ## Options
 

--- a/src/pages/ui-components/components/navigation.md
+++ b/src/pages/ui-components/components/navigation.md
@@ -7,7 +7,7 @@ description: Configure Adobe Commerce and Magento Open Source UI components and 
 
 The Navigation component implements tabs navigation.
 
-See the [Admin Design Pattern Library (Tabs)](https://devdocs.magento.com/guides/v2.4/pattern-library/containers/tabs/tabs.html) topic for information about the UI design patterns that can be implemented using the Nav component.
+See the [Admin Design Pattern Library (Tabs)](https://developer.adobe.com/commerce/admin-developer/pattern-library/containers/tabs/) topic for information about the UI design patterns that can be implemented using the Nav component.
 
 ## Options
 

--- a/src/pages/ui-components/components/tab.md
+++ b/src/pages/ui-components/components/tab.md
@@ -7,7 +7,7 @@ description: Configure Adobe Commerce and Magento Open Source UI components and 
 
 The Tab component implements a tab content area.
 
-See the [Admin Design Pattern Library (Tabs)](https://devdocs.magento.com/guides/v2.4/pattern-library/containers/tabs/tabs.html) topic for information about the UI design patterns that can be implemented using the Tab component.
+See the [Admin Design Pattern Library (Tabs)](https://developer.adobe.com/commerce/admin-developer/pattern-library/containers/tabs/) topic for information about the UI design patterns that can be implemented using the Tab component.
 
 ## Options
 

--- a/src/pages/ui-components/concepts/semantic-configuration.md
+++ b/src/pages/ui-components/concepts/semantic-configuration.md
@@ -110,4 +110,4 @@ To use the autocomplete and validation features in your IDE, generate the URN as
 <!--Link Declarations -->
 
 [declaring a custom UI component]: ../howto/new-component-declaration.md
-[URN highlighter]: https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-urn.html
+[URN highlighter]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/urn-highlighter.html


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces links to `https://devdocs.magento.com` topics that have already been migrated to the Adobe Devsite (`https://developer.adobe.com`).

## Affected pages

- See changed files

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My changes follow the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
