### PR TITLE
Indicate the path more details for di.xml example file

### DIFF
--- a/src/pages/guide/layouts/xml-manage.md
+++ b/src/pages/guide/layouts/xml-manage.md
@@ -345,7 +345,7 @@ The visibility can also be adjusted using the [ACL Resource](https://developer.a
 
 In the admin area, this is implemented for [global search](https://github.com/magento/magento2/blob/2.4/app/code/Magento/Backend/view/adminhtml/layout/default.xml) and for [admin notification list](https://github.com/magento/magento2/blob/2.4/app/code/Magento/AdminNotification/view/adminhtml/layout/default.xml).
 
-## Set the template used by a bloc
+## Set the template used by a block
 
 There are three ways to set the template for a block:
 
@@ -548,7 +548,7 @@ The name provided to the `$block->getData()` function should match the name of t
 Plugins can be also useful, when we need to make some layout updates.
 Here is an example of how a css class can be added to `<body>` tag on product view page.
 
-> `etc/frontend/di.xml`
+> `ExampleCorp/Learning/etc/frontend/di.xml`
 
 ```xml
 <?xml version="1.0"?>


### PR DESCRIPTION
## Description

Currently, the path for di.xml in `Modify layout with plugins (interceptors)` section may be caused misunderstood. It should add VendorName/ModuleName like the `AddBodyClassToProductPagePlugin.php`.

@jeff-matthews in this change, I also fixed the typo "bloc".

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
