### PR TITLE
COMDOX-346: Restore workflow customizations

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,8 +1,7 @@
 ---
 name: Github Pages
 on:
-  push:
-    branches: [main]
+  workflow_dispatch
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -85,6 +85,9 @@ jobs:
         with:
           cmd: install
 
+      - name: Check internal links
+        run: yarn test:links
+
       - name: Build site
         if: ${{ success() }}
         uses: borales/actions-yarn@v3

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AdobeDocs/commerce-frontend-core"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "^4.6.2",
+    "@adobe/gatsby-theme-aio": "4.6.2",
     "gatsby": "4.22.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,7 +33,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/gatsby-theme-aio@npm:^4.6.2":
+"@adobe/gatsby-theme-aio@npm:4.6.2":
   version: 4.6.2
   resolution: "@adobe/gatsby-theme-aio@npm:4.6.2"
   dependencies:
@@ -6638,7 +6638,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "commerce-frontend-core@workspace:."
   dependencies:
-    "@adobe/gatsby-theme-aio": ^4.6.2
+    "@adobe/gatsby-theme-aio": 4.6.2
     gatsby: 4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
## Description

This pull request:

- Restores GitHub Actions workflow customizations that were reverted when the `aio-theme` dependency was bumped to v4.6.2.
- Pins the `gatsby-theme-aio` to v4.6.2 to prevent unexpected or untested releases/changes from breaking the site on each new deployment.

## Related Issue

https://github.com/AdobeDocs/commerce-frontend-core/commit/b4f00b40588a02ae9f91d0bafeec740870340d97

## Motivation and Context

See COMDOX-346 for details

## How Has This Been Tested?

See required checks in PR

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
