### PR TITLE
Add Note Regarding View Config and Emails

### DIFF
--- a/src/pages/guide/themes/configure.md
+++ b/src/pages/guide/themes/configure.md
@@ -72,6 +72,10 @@ All image properties used in `view.xml` should be listed in the order shown here
 | `transparency` | boolean | If set to `true`, the transparent background of images is saved. If is set to `false`, images have the white background (by default). You can set the color for the background using the `background` parameter. Default value: `true`. | Optional |
 | `background` | string | The color for the images background. Not applied to images with transparency, if `transparency` is set to `true`. Format: "[, ,]", e.g.: "[255, 255, 255]". | Optional |
 
+<InlineAlert variant="warning" slots="text"/>
+
+Due to area emulation, emails will ignore `etc/view.xml` configuration files in themes - instead only `etc/view.xml` configurations defined in modules are applied to emails.
+
 ### Resize catalog images
 
 Generally, product images are cached while saving the product. However, the `magento catalog:images:resize` command enables you to resize all images for display on your storefront. Situations where this could be necessary might be:


### PR DESCRIPTION
## Description
Adds a note regarding how `etc/view.xml` configurations are applied to emails during area emulation.

Affected page: https://developer.adobe.com/commerce/frontend-core/guide/themes/configure/

## Motivation and Context
This information does not appear to be documented anywhere and developers will waste time trying to figure out why their theme configuration is not being applied in some scenarios - see [magento/magento2 issue#36340](https://github.com/magento/magento2/issues/36340).

## How Has This Been Tested?
1. Put product out of stock
2. Run relevant indexers
3. Register for a stock alert for the product from step 1
4. Run the `product_alert` queue consumer
5. Observe that only `etc/view.xml` configurations defined in modules are loaded in [`Magento\Framework\Config\View::read()`](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Config/View.php#L212)

## Types of changes

- [x] Documentation update

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
