### PR TITLE
ACP2E-1942: Create known-limitations page for PageBuilder

### DIFF
--- a/src/data/navigation/sections/page_builder.js
+++ b/src/data/navigation/sections/page_builder.js
@@ -8,6 +8,10 @@ module.exports = [
       path: "/page-builder/release-notes.md"
     },
     {
+      title: "Known limitations",
+      path: "/page-builder/known-limitations/"
+    },
+    {
       title: "Example code",
       path: "/page-builder/pagebuilder-examples.md"
     },

--- a/src/pages/page-builder/known-limitations.md
+++ b/src/pages/page-builder/known-limitations.md
@@ -1,9 +1,10 @@
 ---
-title: Known limitations
+title: Known limitations | 
+description: Learn about known limitations for Page Builder on Adobe Commerce and Magento Open Source frontends.
 ---
 
 # Known limitations
 
 The following items are known limitations to the Page Builder content types:
 
-- **Preview and New Relic** - New Relic service workers are not supported in the Page Builder preview mode resulting in a ServiceWorker console error and no functional impact for the Page Builder itself.
+- **Preview and New Relic** - New Relic service workers are not supported in the Page Builder preview mode resulting in a ServiceWorker console error and no functional impact for Page Builder itself.

--- a/src/pages/page-builder/known-limitations.md
+++ b/src/pages/page-builder/known-limitations.md
@@ -1,0 +1,9 @@
+---
+title: Known limitations
+---
+
+# Known limitations
+
+The following items are known limitations to the Page Builder content types:
+
+- **Preview and NewRelic** - NewRelic service workers are not supported in the PageBuilder preview mode resulting in a ServiceWorker console error and no functional impact for the PageBuilder itself.

--- a/src/pages/page-builder/known-limitations.md
+++ b/src/pages/page-builder/known-limitations.md
@@ -6,4 +6,4 @@ title: Known limitations
 
 The following items are known limitations to the Page Builder content types:
 
-- **Preview and NewRelic** - NewRelic service workers are not supported in the PageBuilder preview mode resulting in a ServiceWorker console error and no functional impact for the PageBuilder itself.
+- **Preview and New Relic** - New Relic service workers are not supported in the Page Builder preview mode resulting in a ServiceWorker console error and no functional impact for the Page Builder itself.

--- a/src/pages/page-builder/known-limitations.md
+++ b/src/pages/page-builder/known-limitations.md
@@ -1,9 +1,10 @@
 ---
 title: Known limitations
+description: This page links to the Page Builder known limitations on ExL. 
 ---
 
 # Known limitations
 
-The following items are known limitations to the Page Builder content types:
+Known limitations for Page Builder are hosted on Adobe Experience League as part of the Page Builder User Guide. Follow the link below to open the Page Builder known limitations in a new window:
 
-- **Preview and New Relic** - New Relic service workers are not supported in the Page Builder preview mode resulting in a ServiceWorker console error and no functional impact for the Page Builder itself.
+### [Known limitations for Page Builder](https://experienceleague.adobe.com/docs/commerce-admin/page-builder/known-limitations.html)

--- a/src/pages/page-builder/known-limitations.md
+++ b/src/pages/page-builder/known-limitations.md
@@ -1,10 +1,9 @@
 ---
 title: Known limitations
-description: This page links to the Page Builder known limitations on ExL. 
 ---
 
 # Known limitations
 
-Known limitations for Page Builder are hosted on Adobe Experience League as part of the Page Builder User Guide. Follow the link below to open the Page Builder known limitations in a new window:
+The following items are known limitations to the Page Builder content types:
 
-### [Known limitations for Page Builder](https://experienceleague.adobe.com/docs/commerce-admin/page-builder/known-limitations.html)
+- **Preview and New Relic** - New Relic service workers are not supported in the Page Builder preview mode resulting in a ServiceWorker console error and no functional impact for the Page Builder itself.


### PR DESCRIPTION
## Purpose of this pull request

Per discussion with the PO

- Add a new tab "Known Limitations" to the https://developer.adobe.com/commerce/frontend-core/page-builder/

## Affected pages

New pages added:

- https://developer.adobe.com/commerce/frontend-core/page-builder/known-limitations/

## Links to Magento Open Source code

N/A