### PR TITLE
ACP2E-2187: [Cloud] Youtube video autoplay is not working

### DIFF
--- a/src/pages/guide/themes/product-video.md
+++ b/src/pages/guide/themes/product-video.md
@@ -56,4 +56,3 @@ For the sake of compatibility, upgradability and easy maintenance, do not edit t
 <InlineAlert variant="info" slots="text"/>
 
 If the **Autostart base video** configuration option is set to `Yes` but the video does not begin to play automatically, it could be due to the autoplay policies that are enforced by the browser and cannot be controlled by Adobe Commerce. Each supported browser has its own autoplay policies that can change over time and your video may not autoplay in the future. As a recommended best practice, you should not rely on autoplay for business critical functionality and should test the video autoplay behavior in your store with each supported browser.
-Note that each supported browser has its own autoplay policies that changes over time and your video may not autoplay in the future. We recommend that you do not rely on autoplay for business critical functionality and test the video autoplay behavior in your store with each supported browser.

--- a/src/pages/guide/themes/product-video.md
+++ b/src/pages/guide/themes/product-video.md
@@ -56,4 +56,3 @@ For the sake of compatibility, upgradability and easy maintenance, do not edit t
 <InlineAlert variant="info" slots="text"/>
 
 If the **Autostart base video** configuration option is set to `Yes` but the video does not begin to play automatically, it could be due to the autoplay policies that are enforced by the browser and cannot be controlled by Adobe Commerce. Each supported browser has its own autoplay policies that can change over time and your video may not autoplay in the future. As a recommended best practice, you should not rely on autoplay for business critical functionality and should test the video autoplay behavior in your store with each supported browser.
-

--- a/src/pages/guide/themes/product-video.md
+++ b/src/pages/guide/themes/product-video.md
@@ -52,3 +52,8 @@ For the sake of compatibility, upgradability and easy maintenance, do not edit t
 1. When complete, click _Save Config_.
 
 1. When prompted, refresh the cache.
+
+<InlineAlert variant="info" slots="text"/>
+
+If you have "Autostart base video" configuration option set to Yes, but the video does not begin to play automatically, it could be due to autoplay policies that are enforced by the browser and cannot be controlled by Adobe Commerce.
+Note that each supported browser has its own autoplay policies that changes over time and your video may not autoplay in the future. We recommend that you do not rely on autoplay for business critical functionality and test the video autoplay behavior in your store with each supported browser. 

--- a/src/pages/guide/themes/product-video.md
+++ b/src/pages/guide/themes/product-video.md
@@ -55,5 +55,5 @@ For the sake of compatibility, upgradability and easy maintenance, do not edit t
 
 <InlineAlert variant="info" slots="text"/>
 
-If you have "Autostart base video" configuration option set to Yes, but the video does not begin to play automatically, it could be due to autoplay policies that are enforced by the browser and cannot be controlled by Adobe Commerce.
+If the **Autostart base video** configuration option is set to `Yes` but the video does not begin to play automatically, it could be due to the autoplay policies that are enforced by the browser and cannot be controlled by Adobe Commerce. Each supported browser has its own autoplay policies that can change over time and your video may not autoplay in the future. As a recommended best practice, you should not rely on autoplay for business critical functionality and should test the video autoplay behavior in your store with each supported browser.
 Note that each supported browser has its own autoplay policies that changes over time and your video may not autoplay in the future. We recommend that you do not rely on autoplay for business critical functionality and test the video autoplay behavior in your store with each supported browser.

--- a/src/pages/guide/themes/product-video.md
+++ b/src/pages/guide/themes/product-video.md
@@ -56,4 +56,4 @@ For the sake of compatibility, upgradability and easy maintenance, do not edit t
 <InlineAlert variant="info" slots="text"/>
 
 If you have "Autostart base video" configuration option set to Yes, but the video does not begin to play automatically, it could be due to autoplay policies that are enforced by the browser and cannot be controlled by Adobe Commerce.
-Note that each supported browser has its own autoplay policies that changes over time and your video may not autoplay in the future. We recommend that you do not rely on autoplay for business critical functionality and test the video autoplay behavior in your store with each supported browser. 
+Note that each supported browser has its own autoplay policies that changes over time and your video may not autoplay in the future. We recommend that you do not rely on autoplay for business critical functionality and test the video autoplay behavior in your store with each supported browser.

--- a/src/pages/guide/themes/product-video.md
+++ b/src/pages/guide/themes/product-video.md
@@ -56,3 +56,4 @@ For the sake of compatibility, upgradability and easy maintenance, do not edit t
 <InlineAlert variant="info" slots="text"/>
 
 If the **Autostart base video** configuration option is set to `Yes` but the video does not begin to play automatically, it could be due to the autoplay policies that are enforced by the browser and cannot be controlled by Adobe Commerce. Each supported browser has its own autoplay policies that can change over time and your video may not autoplay in the future. As a recommended best practice, you should not rely on autoplay for business critical functionality and should test the video autoplay behavior in your store with each supported browser.
+


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to add a note about the potential issue with product video autoplay caused by the browser policies. We must note that these policies are being frequently changed and we cannot guarantee that the video will play automatically as expected.

Same update I am posting to https://git.corp.adobe.com/AdobeDocs/commerce-admin.en/pull/212


## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/frontend-core/guide/themes/product-video/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- https://jira.corp.adobe.com/browse/ACP2E-2187

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-frontend-core/blob/main/.github/CONTRIBUTING.md) for more information.
-->
