### PR TITLE
ACP2E-2397: Update documentation for ACP2E-2281

### DIFF
--- a/src/pages/guide/responsive-design/css.md
+++ b/src/pages/guide/responsive-design/css.md
@@ -19,12 +19,12 @@ In the Blank and Luma themes, a "mobile first" approach is used. The order is:
 -  Tablet
 -  Desktop
 
-This means that the styles for mobile devices (screen width less than 768px) are extended by the styles for the higher breakpoints. As the result, the extra styles are never loaded when a store is viewed on a mobile device.
+This means that the styles for mobile devices (screen width is 768px and less) are extended by the styles for the higher breakpoints. As the result, the extra styles are never loaded when a store is viewed on a mobile device.
 
 The mobile and desktop styles are defined in separate files:
 
--  [styles-l.less] is used to generate desktop-specific styles (768px and higher).
--  [styles-m.less] is used to generate basic and mobile-specific styles.
+-  [styles-l.less] is used to generate desktop-specific styles (width higher than 768px).
+-  [styles-m.less] is used to generate basic and mobile-specific styles (width of 768px and less).
 
 ## Breakpoints
 
@@ -35,7 +35,7 @@ The Blank and Luma themes use Less variables to implement the following [breakpo
 -  `@screen__xxs`: 320px
 -  `@screen__xs`: 480px
 -  `@screen__s`: 640px
--  `@screen__m`: 768px (in the Blank and Luma themes, this breakpoint switches between mobile and desktop views)
+-  `@screen__m`: 768px (in the Blank and Luma themes, when the viewport width is more than 768px, this breakpoint switches to the desktop view)
 -  `@screen__l`: 1024px
 -  `@screen__xl`: 1440px
 
@@ -102,8 +102,8 @@ For grouping style rules in certain media queries the `.media-width()` mixin use
 
 // This will add styles for tablet devices. When using native media-queries, we recommend wrapping your media-queries with media-width mixins or media-target
 & when (@media-target = 'desktop'), (@media-target = 'all') {
-    @media only screen and (min-width: @screen__m) and (max-width: (@screen__xl - 1)) {
-        // styles for breakpoint >= 768px and < 1440px
+    @media only screen and (min-width: @screen__m + 1) and (max-width: (@screen__xl - 1)) {
+        // styles for breakpoint > 768px and < 1440px
     }
 }
 
@@ -124,7 +124,7 @@ For grouping style rules in certain media queries the `.media-width()` mixin use
 }
 ```
 
-You can find more information about the UI library responsive mixin usage in `<your_Magento_instance>/pub/static/frontend/Magento/blank/en_US/css/docs/responsive.html` (view in a browser).
+You can find more information about the UI library responsive mixin usage in `<your_Magento_instance>/pub/static/frontend/Magento/blank/en_US/css/docs/responsive.html`.
 
 <!-- Link definitions -->
 [styles-l.less]: https://github.com/magento/magento2/blob/2.4/app/design/frontend/Magento/blank/web/css/styles-l.less


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to resolve inconsistencies between a current system behavior of switching the layout between mobile and desktop modes being triggered at 768px width for mobile and 769px for desktop, as confirmed by the product manager and also, updated the code sample to reflect the current code.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/frontend-core/guide/responsive-design/css/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- https://jira.corp.adobe.com/browse/ACP2E-2397
- https://jira.corp.adobe.com/browse/ACP2E-2281
- https://jira.corp.adobe.com/browse/ACP2E-169

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-frontend-core/blob/main/.github/CONTRIBUTING.md) for more information.
-->
