### PR TITLE
Fix heading typo in ColorPicker UI component topic

### DIFF
--- a/src/pages/ui-components/components/color-picker.md
+++ b/src/pages/ui-components/components/color-picker.md
@@ -1,9 +1,9 @@
 ---
-title: ColorPicker |
+title: ColorPicker | Commerce Frontend Development
 description: Configure Adobe Commerce and Magento Open Source UI components and integrate them with other components.
 ---
 
-# ColoPicker component
+# ColorPicker component
 
 The ColorPicker component uses the [Spectrum](https://bgrins.github.io/spectrum/) and [tinycolor.js](https://bgrins.github.io/TinyColor/) libraries to make it easier to choose and implement color values.
 The ColorPicker component must be a child of the [Listing](listing-grid.md) or [Form](form.md) components.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes #137.

## Affected pages

- https://developer.adobe.com/commerce/frontend-core/ui-components/components/color-picker/

## Links to Magento Open Source code

- n/a