### PR TITLE
ACP2E-2266: update public docs to show how to add / change itemprop f…

### DIFF
--- a/src/pages/guide/layouts/xml-manage.md
+++ b/src/pages/guide/layouts/xml-manage.md
@@ -158,7 +158,29 @@ Use the following examples to include in your own layout themes.
 
 ## Add or change itemprop global attribute for products
 
-To add `itemprop` attribute to another product attribute displayed in the `<body>` element of your layout on product page, create a theme-extending file similar to: `app/design/frontend/<Vendor>/<theme>/Magento_Catalog/layout/catalog_product_view.xml`.
+By default, `itemprop=description` is an argument on the `short_description` attribute of a product, as shown here:
+
+```xml
+<!-- short_description attribute block -->
+<block class="Magento\Catalog\Block\Product\View\Description" name="product.info.overview"
+       template="Magento_Catalog::product/view/attribute.phtml" group="detailed_info" after="product.info.extrahint">
+  <arguments>
+    <argument name="at_call" xsi:type="string">getShortDescription</argument>
+    <argument name="at_code" xsi:type="string">short_description</argument>
+    <argument name="css_class" xsi:type="string">overview</argument>
+    <argument name="at_label" xsi:type="string">none</argument>
+    <argument name="title" translate="true" xsi:type="string">Overview</argument>
+    <argument name="add_attribute" xsi:type="string">itemprop="description"</argument>
+  </arguments>
+</block>
+
+<!-- Example usage -->
+<div class="product attribute overview">
+  <div class="value" itemprop="description">
+    <p>The instructors and routines featured in LifeLong Fitness IV provide safe options to serve all types of physical conditions and abilities. Range of motion, body awareness and breathing practices are essential tools of yogic self-care, essential for maintaining alertness, health, and dignity over a lifetime. The LifeLong Fitness series acknowledges that as we age, the safety and sustainability of our exercise become as important as pushing our limits.
+    </p>
+  </div>
+</div>
 
 By default, `itemprop=description` is added for `short_description` attribute of a product.
 

--- a/src/pages/guide/layouts/xml-manage.md
+++ b/src/pages/guide/layouts/xml-manage.md
@@ -182,7 +182,37 @@ By default, `itemprop=description` is an argument on the `short_description` att
   </div>
 </div>
 
-By default, `itemprop=description` is added for `short_description` attribute of a product.
+To add the `itemprop` attribute to another product attribute displayed in the `<body>` of your product page layout:
+
+1. Create a new theme-extension file similar to the `catalog_product_view.xml` found here: `app/design/frontend/<Vendor>/<theme>/Magento_Catalog/layout/catalog_product_view.xml`.
+2. Within the new file, remove the `add_attribute` argument from the `short_description` attribute block and add it to the `description` attribute block, as shown here:
+
+```xml
+<!-- description attribute block -->
+<block class="Magento\Catalog\Block\Product\View\Description" name="product.info.description" as="description" template="Magento_Catalog::product/view/attribute.phtml" group="detailed_info">
+      <arguments>
+          <argument name="at_call" xsi:type="string">getDescription</argument>
+          <argument name="at_code" xsi:type="string">description</argument>
+          <argument name="css_class" xsi:type="string">description</argument>
+          <argument name="at_label" xsi:type="string">none</argument>
+          <argument name="title" translate="true" xsi:type="string">Details</argument>
+          <argument name="sort_order" xsi:type="string">10</argument>
+          <argument name="add_attribute" xsi:type="string">itemprop="description"</argument>
+      </arguments>
+</block>
+
+<!-- Example usage -->
+<div class="product attribute description">
+  <div class="value" itemprop="description">
+    <p>Luma LifeLong Fitness Series is a world recognized, evidence based exercise program designed specifically for individuals focused on staying active their whole lives. If followed regularly, participants will see improved heart rate and blood pressure, increased mobility, reduced joint pain and overall improvement in functional fitness and health.</p>
+    <ul>
+      <li>10 minute warm up.</li>
+      <li>30 minutes of mild aerobics.</li>
+      <li>20 minutes of strength, stretch and balance.</li>
+      <li>Extensive modifications for varying fitness levels.</li>
+    </ul>
+  </div>
+</div>
 
 ```xml
 <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.overview" template="Magento_Catalog::product/view/attribute.phtml" group="detailed_info" after="product.info.extrahint">

--- a/src/pages/guide/layouts/xml-manage.md
+++ b/src/pages/guide/layouts/xml-manage.md
@@ -198,6 +198,7 @@ To generate `itemprop=description` for `description` attribute, move the `add_at
       </arguments>
 </block>
 ```
+
 ```html
 <div class="product attribute description">
   <div class="value" itemprop="description">

--- a/src/pages/guide/layouts/xml-manage.md
+++ b/src/pages/guide/layouts/xml-manage.md
@@ -156,6 +156,62 @@ Use the following examples to include in your own layout themes.
 </page>
 ```
 
+## Add or change itemprop global attribute for products
+
+To add `itemprop` attribute to another product attribute displayed in the `<body>` element of your layout on product page, create a theme-extending file similar to: `app/design/frontend/<Vendor>/<theme>/Magento_Catalog/layout/catalog_product_view.xml`.
+
+By default, `itemprop=description` is added for `short_description` attribute of a product.
+
+```xml
+<block class="Magento\Catalog\Block\Product\View\Description" name="product.info.overview" template="Magento_Catalog::product/view/attribute.phtml" group="detailed_info" after="product.info.extrahint">
+    <arguments>
+        <argument name="at_call" xsi:type="string">getShortDescription</argument>
+        <argument name="at_code" xsi:type="string">short_description</argument>
+        <argument name="css_class" xsi:type="string">overview</argument>
+        <argument name="at_label" xsi:type="string">none</argument>
+        <argument name="title" translate="true" xsi:type="string">Overview</argument>
+        <argument name="add_attribute" xsi:type="string">itemprop="description"</argument>
+    </arguments>
+</block>
+```
+
+```html
+<div class="product attribute overview">
+        <div class="value" itemprop="description">
+          <p>The instructors and routines featured in LifeLong Fitness IV provide safe options to serve all types of physical conditions and abilities. Range of motion, body awareness and breathing practices are essential tools of yogic self-care, essential for maintaining alertness, health, and dignity over a lifetime. The LifeLong Fitness series acknowledges that as we age, the safety and sustainability of our exercise become as important as pushing our limits.</p>
+        </div>
+</div>
+```
+
+To generate `itemprop=description` for `description` attribute, move the `add_attribute` argument from `short_description` to `description` xml configuration:
+
+```xml
+<block class="Magento\Catalog\Block\Product\View\Description" name="product.info.description" as="description" template="Magento_Catalog::product/view/attribute.phtml" group="detailed_info">
+      <arguments>
+          <argument name="at_call" xsi:type="string">getDescription</argument>
+          <argument name="at_code" xsi:type="string">description</argument>
+          <argument name="css_class" xsi:type="string">description</argument>
+          <argument name="at_label" xsi:type="string">none</argument>
+          <argument name="title" translate="true" xsi:type="string">Details</argument>
+          <argument name="sort_order" xsi:type="string">10</argument>
+          <argument name="add_attribute" xsi:type="string">itemprop="description"</argument>
+      </arguments>
+</block>
+```
+```html
+<div class="product attribute description">
+  <div class="value" itemprop="description">
+    <p>Luma LifeLong Fitness Series is a world recognized, evidence based exercise program designed specifically for individuals focused on staying active their whole lives. If followed regularly, participants will see improved heart rate and blood pressure, increased mobility, reduced joint pain and overall improvement in functional fitness and health.</p>
+    <ul>
+      <li>10 minute warm up.</li>
+      <li>30 minutes of mild aerobics.</li>
+      <li>20 minutes of strength, stretch and balance.</li>
+      <li>Extensive modifications for varying fitness levels.</li>
+    </ul>
+  </div>
+</div>
+```
+
 ## Create a container
 
 Use the following sample to create (declare) a container:


### PR DESCRIPTION
…or product attributes

## Purpose of this pull request

This pull request (PR) shows how to add / change itemprop on product page. This is already existing functionality and is needed for Google Search Console.

## Affected pages
https://developer.adobe.com/commerce/frontend-core/guide/layouts/xml-manage/
<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code
https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-frontend-core/blob/main/.github/CONTRIBUTING.md) for more information.
-->
