### PR TITLE
Correct misspelled word in upgrade-content-types.md

### DIFF
--- a/src/pages/page-builder/upgrade-content-types.md
+++ b/src/pages/page-builder/upgrade-content-types.md
@@ -193,7 +193,7 @@ For example, if you have created a blog entity that stores Page Builder content,
 <type name="Magento\PageBuilder\Model\UpgradableEntitiesPool">
     <arguments>
         <argument name="entities" xsi:type="array">
-            <item name="cms_blog" xsi:type="array">
+            <item name="cms_block" xsi:type="array">
                 <item name="identifier" xsi:type="string">blog_id</item>
                 <item name="fields" xsi:type="array">
                     <item name="content" xsi:type="boolean">true</item>


### PR DESCRIPTION

## Purpose of this pull request

There is a misspelled word (`cms_blog`) on the example provided under `UpgradableEntitiesPool` entities node.

## Affected pages

- https://developer.adobe.com/commerce/frontend-core/page-builder/upgrade-content-types/

## Links to Magento Open Source code

- None
