### PR TITLE
Upgrade theme to v4.11.9

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -66,8 +66,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-          cache: 'yarn'
-          cache-dependency-path: 'yarn.lock'
 
       - name: Enable Corepack for Yarn
         run: corepack enable

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -20,7 +20,7 @@ on: pull_request
 # Set the Job #
 ###############
 jobs:
-  validate:
+  lint:
     # Set the agent to run on
     runs-on: ubuntu-latest
 
@@ -62,19 +62,40 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_GITHUB_ACTIONS: true
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: yarn install
-        env:
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
-      - name: Check links
+      - name: Run tests
         run: yarn test
+  
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
+
+      - name: Install dependencies
+        run: yarn install
 
       - name: Build site
-        if: ${{ success() }}
         run: yarn build

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -67,9 +67,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: Enable Corepack for Yarn
-        run: corepack enable
-
       - name: Install Dependencies
         run: yarn install
         env:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AdobeDocs/commerce-frontend-core"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "^4.11.3",
+    "@adobe/gatsby-theme-aio": "4.11.9",
     "gatsby": "4.22.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/src/pages/javascript/index.md
+++ b/src/pages/javascript/index.md
@@ -37,7 +37,7 @@ JavaScript automatic testing is described in a separate [JavaScript unit testing
 [AMD module]: http://requirejs.org/docs/whyamd.html#amd
 [`Magento_Ui`]: https://github.com/magento/magento2/blob/2.4/app/code/Magento/Ui
 [app/code/Magento/Ui/view]: https://github.com/magento/magento2/blob/2.4/app/code/Magento/Ui/view
-[jQuery UI library]: https://github.com/magento/magento2/blob/2.4/lib/web/jquery/jquery-ui-1.9.2.js
+[jQuery UI library]: https://github.com/magento/magento2/blob/2.4/lib/web/jquery/jquery-ui.js
 [jQuery Widget]: https://jqueryui.com/widget/
 
 [RequireJS file and module loader]: http://requirejs.org/

--- a/src/pages/javascript/jquery-widgets/list.md
+++ b/src/pages/javascript/jquery-widgets/list.md
@@ -12,8 +12,6 @@ The list widget is deprecated since version 2.2.0. As an alternative component f
 Provides a way to move items, typically a list, from one content section to another.
 The content can be moved using buttons and links.
 
-The list widget source file is [lib/web/mage/list.js](https://github.com/magento/magento2/blob/2.4/lib/web/mage/list.js).
-
 ## Initialize
 
 For information about how to initialize a widget in a JS component or `.phtml` template, see the [Initialize JavaScript](../init.md) topic.

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,9 +33,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/gatsby-theme-aio@npm:^4.11.3":
-  version: 4.11.3
-  resolution: "@adobe/gatsby-theme-aio@npm:4.11.3"
+"@adobe/gatsby-theme-aio@npm:4.11.9":
+  version: 4.11.9
+  resolution: "@adobe/gatsby-theme-aio@npm:4.11.9"
   dependencies:
     "@adobe/focus-ring-polyfill": ^0.1.5
     "@adobe/gatsby-source-github-file-contributors": ^0.3.1
@@ -131,7 +131,7 @@ __metadata:
     gatsby: ^4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: 36b7256aba793747b6da40b867b8ad4ecd32835c1ea5bc76ee3fef5cd73d7aa14ba9734ef3c5a7db6866d806fc61afd02bf44053a1ffdd93ec8016cf130f84b7
+  checksum: 57693d220f785d6ffa8c81c09fce1b15240de6ce483df835b5b5b373124e1b1349c99f170b2694c25b2271aff84b16eef8e5975c1f7b33f24a297a3b03e8e871
   languageName: node
   linkType: hard
 
@@ -6961,7 +6961,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "commerce-frontend-core@workspace:."
   dependencies:
-    "@adobe/gatsby-theme-aio": ^4.11.3
+    "@adobe/gatsby-theme-aio": 4.11.9
     gatsby: 4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) upgrades theme to [v4.11.9](https://github.com/adobe/aio-theme/compare/%40adobe/gatsby-theme-aio%404.11.3...%40adobe/gatsby-theme-aio%404.11.9).

Jira: COMDOX-913

## Preview

https://developer-stage.adobe.com/commerce/frontend-core/