### PR TITLE
ACP2E-3031: Update the documentation on OM in templates

### DIFF
--- a/src/pages/guide/layouts/xml-instructions.md
+++ b/src/pages/guide/layouts/xml-instructions.md
@@ -412,6 +412,8 @@ The argument with *helper* type can contain `param` items which can be passed as
 
 import Docs from '/src/_includes/objects-in-templates.md'
 
+<Docs />
+
 These argument examples can be taken in the template by *getData* method. Another way to take these arguments is using the magic method *get* followed by the name of argument in CamelCase format. Here is an example to retrieve the arguments from above example:
 
 ```php

--- a/src/pages/guide/templates/override.md
+++ b/src/pages/guide/templates/override.md
@@ -81,6 +81,8 @@ Arguments values set in a layout file are accessed in templates using the block'
 
 import Docs from '/src/_includes/objects-in-templates.md'
 
+<Docs />
+
 For example, set an argument in the block: `<argument name="store_name" xsi:type="string">ExampleCorp</argument>`.
 
 *  Get the argument value, in the template:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to add a note to technical guidelines about instantiation of the new objects from templates to avoid confusion.

**Please note I am keeping this as draft for collaboration between developers to edit and approve and will change the status once we will be done. Thanks.**

Related PR: https://github.com/AdobeDocs/commerce-php/pull/261

## Affected pages
- https://developer.adobe.com/commerce/frontend-core/guide/templates/override/#getting-argument-values-from-layout
- https://developer.adobe.com/commerce/frontend-core/guide/layouts/xml-instructions/#obtain-arguments-examples-in-template

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->


<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-frontend-core/blob/main/.github/CONTRIBUTING.md) for more information.
-->
