### PR TITLE
ACP2E-3042: Update the documentation on mobile/ desktop breakpoints (rollback previous changes)

### DIFF
--- a/src/pages/guide/responsive-design/css.md
+++ b/src/pages/guide/responsive-design/css.md
@@ -19,12 +19,12 @@ In the Blank and Luma themes, a "mobile first" approach is used. The order is:
 -  Tablet
 -  Desktop
 
-This means that the styles for mobile devices (screen width is 768px and less) are extended by the styles for the higher breakpoints. As the result, the extra styles are never loaded when a store is viewed on a mobile device.
+This means that the styles for mobile devices (screen width is 767px and less) are extended by the styles for the higher breakpoints. As the result, the extra styles are never loaded when a store is viewed on a mobile device.
 
 The mobile and desktop styles are defined in separate files:
 
--  [styles-l.less] is used to generate desktop-specific styles (width higher than 768px).
--  [styles-m.less] is used to generate basic and mobile-specific styles (width of 768px and less).
+-  [styles-l.less] is used to generate desktop-specific styles (width higher than 767px).
+-  [styles-m.less] is used to generate basic and mobile-specific styles (width of 767px and less).
 
 ## Breakpoints
 
@@ -35,7 +35,7 @@ The Blank and Luma themes use Less variables to implement the following [breakpo
 -  `@screen__xxs`: 320px
 -  `@screen__xs`: 480px
 -  `@screen__s`: 640px
--  `@screen__m`: 768px (in the Blank and Luma themes, when the viewport width is more than 768px, this breakpoint switches to the desktop view)
+-  `@screen__m`: 767px (in the Blank and Luma themes, when the viewport width is more than 767px, this breakpoint switches to the desktop view)
 -  `@screen__l`: 1024px
 -  `@screen__xl`: 1440px
 
@@ -102,8 +102,8 @@ For grouping style rules in certain media queries the `.media-width()` mixin use
 
 // This will add styles for tablet devices. When using native media-queries, we recommend wrapping your media-queries with media-width mixins or media-target
 & when (@media-target = 'desktop'), (@media-target = 'all') {
-    @media only screen and (min-width: @screen__m + 1) and (max-width: (@screen__xl - 1)) {
-        // styles for breakpoint > 768px and < 1440px
+    @media only screen and (min-width: @screen__m) and (max-width: (@screen__xl - 1)) {
+        // styles for breakpoint >= 768px and < 1440px
     }
 }
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to rollback the change from https://github.com/AdobeDocs/commerce-frontend-core/pull/136 since the decision has been changed by the PM regarding the breakpoints that toggle mobile<>desktop layouts.

I am targeting 2.4.8-develop here since the changes won't be released until then.

https://jira.corp.adobe.com/browse/ACP2E-2966

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/frontend-core/guide/responsive-design/css/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-frontend-core/blob/main/.github/CONTRIBUTING.md) for more information.
-->
