### PR TITLE
Add source content from ExL repo

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -19,7 +19,7 @@ jobs:
         run: corepack enable
 
       - name: Install Yarn v3
-        run: yarn set version .yarn/releases/yarn-3.2.4.cjs
+        run: yarn set version ./.yarn/releases/yarn-3.2.4.cjs
 
       - name: Install Dependencies
         run: yarn install

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -15,6 +15,9 @@ jobs:
 
       - name: Enable Corepack for Yarn
         run: corepack enable
+      
+      - name: Clean Cache
+        run: yarn cache clean
 
       - name: Install Dependencies
         run: yarn install

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Enable Corepack for Yarn
         run: corepack enable
 
+      - name: Install Yarn v3
+        uses: borales/actions-yarn@v3
+        with:
+          cmd: set version stable
+
       - name: Install Dependencies
         run: yarn install
         env:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -12,8 +12,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-          cache: 'yarn'
-          cache-dependency-path: 'yarn.lock'
 
       - name: Enable Corepack for Yarn
         run: corepack enable

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -19,7 +19,7 @@ jobs:
         run: corepack enable
 
       - name: Install Yarn v3
-        uses: yarn set version .yarn/releases/yarn-3.2.4.cjs
+        run: yarn set version .yarn/releases/yarn-3.2.4.cjs
 
       - name: Install Dependencies
         run: yarn install

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -19,9 +19,7 @@ jobs:
         run: corepack enable
 
       - name: Install Yarn v3
-        uses: borales/actions-yarn@v3
-        with:
-          cmd: set version stable
+        uses: yarn set version .yarn/releases/yarn-3.2.4.cjs
 
       - name: Install Dependencies
         run: yarn install

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Enable Corepack for Yarn
         run: corepack enable
 
-      - name: Install Yarn v3
-        run: yarn set version ./.yarn/releases/yarn-3.2.4.cjs
-
       - name: Install Dependencies
         run: yarn install
         env:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,2 @@
 nodeLinker: node-modules
 yarnPath: .yarn/releases/yarn-3.2.4.cjs
-checkumBehavior: update

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,3 @@
 nodeLinker: node-modules
-
 yarnPath: .yarn/releases/yarn-3.2.4.cjs
+checkumBehavior: update

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@adobe/gatsby-theme-aio": "4.14.4",
+    "commerce-admin.en": "https://github.com/AdobeDocs/commerce-admin.en#ds_remote-md",
     "gatsby": "4.22.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@adobe/gatsby-theme-aio": "4.14.4",
-    "commerce-admin.en": "https://github.com/AdobeDocs/commerce-admin.en#ds_remote-md",
+    "commerce-admin.en": "https://github.com/AdobeDocs/commerce-admin.en.git#commit=f68c365f7f3b13a8c5f04be17cd8b2537d1eeefe",
     "gatsby": "4.22.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/src/pages/page-builder/release-notes.md
+++ b/src/pages/page-builder/release-notes.md
@@ -5,8 +5,10 @@ keywords:
   - Page Builder
 ---
 
+import ReleaseNotes from 'commerce-admin.en/help/page-builder/release-notes.md'
+
 # Release notes for Page Builder
 
 The Release notes for Page Builder are hosted on Adobe Experience League as part of the Page Builder User Guide. Follow the link below to open the Page Builder release notes in a new window:
 
-### [Release notes for Page Builder](https://experienceleague.adobe.com/docs/commerce-admin/page-builder/release-notes.html)
+<ReleaseNotes />

--- a/yarn.lock
+++ b/yarn.lock
@@ -10382,11 +10382,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commerce-admin.en@https://github.com/AdobeDocs/commerce-admin.en#ds_remote-md":
+  version: 1.0.0
+  resolution: "commerce-admin.en@https://github.com/AdobeDocs/commerce-admin.en.git#commit=870233dc949eefc59005f8785b8858b86f64e523"
+  checksum: 2fee20649a4965c7db91f7b897ea401d3a932f8022bceab69766b2eaea7bdbb48db313d0d60922c7b26e834fbfcf072917aae24b933394002610f5dadac795b3
+  languageName: node
+  linkType: hard
+
 "commerce-frontend-core@workspace:.":
   version: 0.0.0-use.local
   resolution: "commerce-frontend-core@workspace:."
   dependencies:
     "@adobe/gatsby-theme-aio": 4.14.4
+    commerce-admin.en: "https://github.com/AdobeDocs/commerce-admin.en#ds_remote-md"
     gatsby: 4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -10382,10 +10382,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commerce-admin.en@https://github.com/AdobeDocs/commerce-admin.en#ds_remote-md":
+"commerce-admin.en@https://github.com/AdobeDocs/commerce-admin.en.git#commit=f68c365f7f3b13a8c5f04be17cd8b2537d1eeefe":
   version: 1.0.0
-  resolution: "commerce-admin.en@https://github.com/AdobeDocs/commerce-admin.en.git#commit=870233dc949eefc59005f8785b8858b86f64e523"
-  checksum: 2fee20649a4965c7db91f7b897ea401d3a932f8022bceab69766b2eaea7bdbb48db313d0d60922c7b26e834fbfcf072917aae24b933394002610f5dadac795b3
+  resolution: "commerce-admin.en@https://github.com/AdobeDocs/commerce-admin.en.git#commit=f68c365f7f3b13a8c5f04be17cd8b2537d1eeefe"
+  checksum: 258bb46c1cd119c527fee9f82cd7ba297fd3a71b6b1aa4bec12d3a2689ef5d2de0d0f431c495ec0ac60518314d479b15720dc8b13c64e6794421dadf94d2c32f
   languageName: node
   linkType: hard
 
@@ -10394,7 +10394,7 @@ __metadata:
   resolution: "commerce-frontend-core@workspace:."
   dependencies:
     "@adobe/gatsby-theme-aio": 4.14.4
-    commerce-admin.en: "https://github.com/AdobeDocs/commerce-admin.en#ds_remote-md"
+    commerce-admin.en: "https://github.com/AdobeDocs/commerce-admin.en.git#commit=f68c365f7f3b13a8c5f04be17cd8b2537d1eeefe"
     gatsby: 4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) demonstrates sourcing a [DevSite topic](https://developer.adobe.com/commerce/frontend-core/page-builder/release-notes/) with [remote ExL content](https://experienceleague.adobe.com/en/docs/commerce-admin/page-builder/release-notes).

See discussion in https://github.com/AdobeDocs/commerce-frontend-core/pull/50.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- [page-builder/release-notes/](https://developer.adobe.com/commerce/frontend-core/page-builder/release-notes/)

Preview: https://commerce-docs.github.io/commerce-frontend-core/page-builder/release-notes/