### PR TITLE
Update links to decommissioned resources

### DIFF
--- a/src/pages/guide/caching.md
+++ b/src/pages/guide/caching.md
@@ -113,9 +113,9 @@ You can clean generated static view files in any of the following ways:
 
 -  Several commands support an optional parameter `--clear-static-content`, which cleans generated static view files:
 
-   -  [`magento module:enable` and `magento module:disable`](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-subcommands-enable.html)
-   -  [`magento theme:uninstall`](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-theme-uninstall.html)
-   -  [`magento module:uninstall`](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-uninstall-mods.html)
+   -  [`magento module:enable` and `magento module:disable`](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/tutorials/manage-modules)
+   -  [`magento theme:uninstall`](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/tutorials/themes)
+   -  [`magento module:uninstall`](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/tutorials/uninstall-modules)
 
 ## Clean static files
 

--- a/src/pages/guide/themes/apply-admin.md
+++ b/src/pages/guide/themes/apply-admin.md
@@ -37,7 +37,7 @@ If you decide to use the existing module, keep in mind, that theme declaring mig
 To apply the Admin theme, take the following steps:
 
 1. [Specify the new Admin theme in your module's `di.xml`](#specify-the-custom-admin-theme-in-dixml)
-1. Update the components by running the [`bin/magento setup:upgrade`](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-uninstall.html#instgde-install-keep) command.
+1. Update the components by running the [`bin/magento setup:upgrade`](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/tutorials/uninstall) command.
 1. Open the Admin in browser and view the new theme applied.
 
 Each step is described further with more details.
@@ -71,7 +71,7 @@ run the `bin/magento setup:upgrade` command in your command line. If prompted, a
 For details about performing command line tasks, view the following topics:
 
 -  [Command line configuration](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/config-cli.html)
--  [Uninstall or reinstall the application: Optionally keeping generated files](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-subcommands-db-upgr.html)
+-  [Uninstall or reinstall the application: Optionally keeping generated files](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/tutorials/database-upgrade)
 
 ## Open Admin in browser
 

--- a/src/pages/guide/themes/create-storefront.md
+++ b/src/pages/guide/themes/create-storefront.md
@@ -151,7 +151,7 @@ Product image sizes and other properties used on the storefront are configured i
 
 If the product image sizes of your theme differ from those of the parent theme, or if your theme does not inherit from any theme, add `view.xml` using the following steps:
 
-1. Log in to your application server as a user with permissions to create directories and files in the installation directory. (Typically, this is the [file system owner](https://devdocs.magento.com/guides/v2.4/install-gde/prereq/apache.html).)
+1. Log in to your application server as a user with permissions to create directories and files in the installation directory. (Typically, this is the [file system owner](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/prerequisites/web-server/apache).)
 
 1. Create the `etc` directory in your theme folder.
 

--- a/src/pages/guide/themes/install.md
+++ b/src/pages/guide/themes/install.md
@@ -33,7 +33,7 @@ To install a theme manually:
 
 ## Composer install
 
-To install the theme as composer package, follow the instructions in the [Install, manage, and upgrade modules](https://devdocs.magento.com/cloud/howtos/install-components.html) topic.
+To install the theme as composer package, follow the instructions in the [Install, manage, and upgrade modules](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/configure-store/extensions) topic.
 
 -  Manually installed themes are stored in the `app/design/` directory. Themes loaded through Composer are located in the `vendor/` directory and can be stored anywhere in root.
 
@@ -45,7 +45,7 @@ Composer-based themes are loaded from external sources and cannot be modified di
 
 ## Marketplace extension install
 
-If a theme is distributed on [Commerce Marketplace](https://marketplace.magento.com/), see [Install the Extension](https://devdocs.magento.com/extensions/install/).
+If a theme is distributed on [Commerce Marketplace](https://marketplace.magento.com/), see [Install the Extension](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/tutorials/extensions).
 
 ## Register a theme
 

--- a/src/pages/guide/themes/product-video.md
+++ b/src/pages/guide/themes/product-video.md
@@ -9,7 +9,7 @@ keywords:
 
 # Configure product video
 
-You can add video from external resources (currently, from [YouTube](https://youtube.com) and [Vimeo](https://vimeo.com/)) on product pages. Video is [added in Admin](https://docs.magento.com/user-guide/catalog/product-video.html) when creating or editing a product.
+You can add video from external resources (currently, from [YouTube](https://youtube.com) and [Vimeo](https://vimeo.com/)) on product pages. Video is [added in Admin](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/digital-assets/product-video) when creating or editing a product.
 
 Certain product video options can be set in the `config.xml` configuration file. These settings are not theme-specific.
 

--- a/src/pages/guide/themes/uninstall.md
+++ b/src/pages/guide/themes/uninstall.md
@@ -15,7 +15,7 @@ This topic describes how to uninstall a storefront theme.
 The way a theme should be uninstalled is defined by two factors:
 
 *  The way the theme was added: manually added (installed or created), installed as composer package or as an extension.
-*  The way the application was installed: [using the source files from GitHub](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-sample-data-clone.html) or [using Composer](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-sample-data-composer.html).
+*  The way the application was installed: [using the source files from GitHub](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/next-steps/sample-data/git-repositories) or [using Composer](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/next-steps/sample-data/composer-packages).
 
 The following sections describe the flow for uninstalling themes in each case.
 
@@ -51,7 +51,7 @@ The flow for uninstalling a theme that is Composer package is different, dependi
 
 ### Composer-based installations
 
-If both the theme and the instance were installed using Composer, you can use a special CLI command. Follow the instructions from the [Uninstall themes Composer package](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-theme-uninstall.html) topic.
+If both the theme and the instance were installed using Composer, you can use a special CLI command. Follow the instructions from the [Uninstall themes Composer package](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/tutorials/themes) topic.
 
 ### Git-based installations
 
@@ -75,7 +75,7 @@ Take the following steps:
    composer update
    ```
 
-1. Use the `magento theme:uninstall` CLI command as described in the [Uninstall themes Composer package](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-theme-uninstall.html) topic.
+1. Use the `magento theme:uninstall` CLI command as described in the [Uninstall themes Composer package](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/tutorials/themes) topic.
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/guide/translations/dictionary.md
+++ b/src/pages/guide/translations/dictionary.md
@@ -20,7 +20,7 @@ When the locale is changed for a store, the application searches and applies tra
 1. Theme translations:
    1. `<parent_theme_dir>/i18n/` (iterated through all ancestor themes)
    1. `<current_theme_dir>/i18n/`
-1. The database (translations located in this database take precedence and override translations stored in other locations.)  Refer to the [user guide](https://docs.magento.com/m2/ce/user_guide/system/translate-inline.html) for more information.
+1. The database (translations located in this database take precedence and override translations stored in other locations.)  Refer to the [user guide](https://experienceleague.adobe.com/en/docs/commerce-admin/systems/tools/developer-tools#translate-inline) for more information.
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/guide/translations/index.md
+++ b/src/pages/guide/translations/index.md
@@ -113,7 +113,7 @@ You can generate a translation dictionary to use by itself (for example, to tran
 
 <InlineAlert variant="success" slots="text"/>
 
-Existing language packages can be installed using [Composer](https://devdocs.magento.com/cloud/howtos/install-components.html) like any other extension. You can search for package names on Packagist.
+Existing language packages can be installed using [Composer](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/configure-store/extensions) like any other extension. You can search for package names on Packagist.
 
 The application enables you to create the following types of language packages:
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -23,7 +23,7 @@ Learn how to develop web-based storefronts for Adobe Commerce and Magento Open S
 *  [Community Slack workspace](https://opensource.magento.com/slack)
 *  [Contributor statistics](https://developer.adobe.com/open/magento/statistic)
 *  [PWA Studio](https://developer.adobe.com/open/magento)
-*  [Page Builder](https://devdocs.magento.com/page-builder/docs/index.html)
+*  [Page Builder](page-builder/)
 
 ## Overview
 

--- a/src/pages/page-builder/content-types/create/add-form.md
+++ b/src/pages/page-builder/content-types/create/add-form.md
@@ -289,7 +289,7 @@ The `<settings>` element defines the data scope, data type, and label to use for
 
 ## Quote form layout
 
-The layout for our Quote form is shown in full here for you to copy into your `pagebuilder_example_form.xml` layout file. For more information about layouts, see [Layout instructions](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/xml-instructions.html).
+The layout for our Quote form is shown in full here for you to copy into your `pagebuilder_example_form.xml` layout file. For more information about layouts, see [Layout instructions](/guide/layouts/xml-instructions/).
 
 ```xml
 <?xml version="1.0"?>

--- a/src/pages/page-builder/content-types/customize/add-icons-images.md
+++ b/src/pages/page-builder/content-types/customize/add-icons-images.md
@@ -132,6 +132,6 @@ For more general information about Adobe Commerce's Admin icons and how to creat
 
 -  [The CMS icons repository]
 
-[Commerce Admin icons]: https://devdocs.magento.com/guides/v2.3/pattern-library/graphics/iconography/iconography.html
-[Create your own icons]: https://devdocs.magento.com/guides/v2.3/pattern-library/graphics/iconography/iconography.html#creating-icons
+[Commerce Admin icons]: https://developer.adobe.com/commerce/admin-developer/pattern-library/graphics/iconography/
+[Create your own icons]: https://developer.adobe.com/commerce/admin-developer/pattern-library/graphics/iconography/#creating-icons
 [The CMS icons repository]: https://github.com/magento-ux/cms-icons

--- a/src/pages/page-builder/contributors.md
+++ b/src/pages/page-builder/contributors.md
@@ -18,7 +18,7 @@ For everyone else, Page Builder is automatically installed with Adobe Commerce 2
 
 Before installing Page Builder for making contributions, you must have the following prerequisites:
 
--  A local development installation of Adobe Commerce 2.3.1+ -- Use the installation instructions from the [DevDocs installation guide](https://devdocs.magento.com/guides/v2.3/install-gde/bk-install-guide.html).
+-  A local development installation of Adobe Commerce 2.3.1+ -- Use the installation instructions from the [DevDocs installation guide](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/overview).
 
 -  Access to the private Page Builder repository. You should participate in [Adobe Partner Program](https://business.adobe.com/products/magento/partners.html) to have these permissions.
 

--- a/src/pages/page-builder/migration/how-content-migration-works.md
+++ b/src/pages/page-builder/migration/how-content-migration-works.md
@@ -178,7 +178,7 @@ The significant parts of a content type renderer are as follows:
 
 #### Constructor dependency injection
 
-First, we use [dependency injection](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/depend-inj.html) to include our dependencies. These are all aspects of Data Migration that aid in retrieving and formatting data along with rendering DOM elements. We go into these in more detail below.
+First, we use [dependency injection](https://developer.adobe.com/commerce/php/development/components/dependency-injection/) to include our dependencies. These are all aspects of Data Migration that aid in retrieving and formatting data along with rendering DOM elements. We go into these in more detail below.
 
 ```php
     public function __construct(
@@ -286,7 +286,7 @@ Some content types do not persist content to the database, such as the row and c
 
 In this example, the EAV loader for Heading is assigned the `title` and `heading_type` attributes, this ensures the EAV attribute loader will retrieve these values within your renderer. Failing to include an attribute here will result in that attribute not being loaded.
 
-We then use [dependency injection](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/depend-inj.html) to inject our virtual configurable EAV loader into the Heading renderer.
+We then use [dependency injection](https://developer.adobe.com/commerce/php/development/components/dependency-injection/) to inject our virtual configurable EAV loader into the Heading renderer.
 
 **Example `di.xml` entry for Heading renderer:**
 

--- a/src/pages/page-builder/migration/install-migration-module.md
+++ b/src/pages/page-builder/migration/install-migration-module.md
@@ -25,7 +25,7 @@ Before installing the migration module, you need to prepare the environment you 
 
 -  Upgrade to Commerce 2.3.1 (which includes Page Builder).
 
-  Please see our [Command-line upgrade](https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html) instructions on how to complete this.
+  Please see our [Command-line upgrade](https://experienceleague.adobe.com/en/docs/commerce-operations/upgrade-guide/implementation/perform-upgrade) instructions on how to complete this.
   Page Builder itself does not convert any of your content. We preserve your existing BlueFoot content when we install Page Builder.
 
 ## Composer installation

--- a/src/pages/page-builder/migration/migrate-content-custom-blocks.md
+++ b/src/pages/page-builder/migration/migrate-content-custom-blocks.md
@@ -113,7 +113,7 @@ bin/magento setup:upgrade
 
 ## Step 6: Add a new setup patch
 
-Create a new data patch inline with our [declarative schema documentation](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/declarative-schema/data-patches.html). For this migration, we first declare the following dependencies in the constructor:
+Create a new data patch inline with our [declarative schema documentation](https://developer.adobe.com/commerce/php/development/components/declarative-schema/patches/). For this migration, we first declare the following dependencies in the constructor:
 
 -  `Magento\Framework\EntityManager\MetadataPool`
 

--- a/src/pages/ui-components/howto/add-category-attribute.md
+++ b/src/pages/ui-components/howto/add-category-attribute.md
@@ -89,7 +89,7 @@ Here is a full example of adding a field under the "Display Settings" group. It 
 
 ## Step #3: Upgrade and run
 
-[Upgrade the database schema](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-subcommands-db-upgr.html) to install the attribute [and clear your cache](https://developer.adobe.com/commerce/php/development/components/clear-directories/#how-to-clear-the-directories).
+[Upgrade the database schema](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/tutorials/database-upgrade) to install the attribute [and clear your cache](https://developer.adobe.com/commerce/php/development/components/clear-directories/#how-to-clear-the-directories).
 
 ## How it works
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces links to decommissioned resources with final destinations.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/frontend-core/guide/caching/
- https://developer.adobe.com/commerce/frontend-core/guide/themes/apply-admin/
- https://developer.adobe.com/commerce/frontend-core/guide/themes/create-storefront/
- https://developer.adobe.com/commerce/frontend-core/guide/themes/install/
- https://developer.adobe.com/commerce/frontend-core/guide/themes/product-video/
- https://developer.adobe.com/commerce/frontend-core/guide/themes/uninstall/
- https://developer.adobe.com/commerce/frontend-core/guide/translations/dictionary/
- https://developer.adobe.com/commerce/frontend-core/guide/translations/index/
- https://developer.adobe.com/commerce/frontend-core/index/
- https://developer.adobe.com/commerce/frontend-core/page-builder/content-types/create/add-form/
- https://developer.adobe.com/commerce/frontend-core/page-builder/content-types/customize/add-icons-images/
- https://developer.adobe.com/commerce/frontend-core/page-builder/contributors/
- https://developer.adobe.com/commerce/frontend-core/page-builder/migration/how-content-migration-works/
- https://developer.adobe.com/commerce/frontend-core/page-builder/migration/install-migration-module/
- https://developer.adobe.com/commerce/frontend-core/page-builder/migration/migrate-content-custom-blocks/
- https://developer.adobe.com/commerce/frontend-core/ui-components/howto/add-category-attribute/
