### PR TITLE
Update xml-manage.md

### DIFF
--- a/src/pages/guide/layouts/xml-manage.md
+++ b/src/pages/guide/layouts/xml-manage.md
@@ -173,7 +173,9 @@ By default, `itemprop=description` is an argument on the `short_description` att
     <argument name="add_attribute" xsi:type="string">itemprop="description"</argument>
   </arguments>
 </block>
+```
 
+```html
 <!-- Example usage -->
 <div class="product attribute overview">
   <div class="value" itemprop="description">
@@ -181,7 +183,7 @@ By default, `itemprop=description` is an argument on the `short_description` att
     </p>
   </div>
 </div>
-
+```
 To add the `itemprop` attribute to another product attribute displayed in the `<body>` of your product page layout:
 
 1. Create a new theme-extension file similar to the `catalog_product_view.xml` found here: `app/design/frontend/<Vendor>/<theme>/Magento_Catalog/layout/catalog_product_view.xml`.
@@ -190,17 +192,19 @@ To add the `itemprop` attribute to another product attribute displayed in the `<
 ```xml
 <!-- description attribute block -->
 <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.description" as="description" template="Magento_Catalog::product/view/attribute.phtml" group="detailed_info">
-      <arguments>
-          <argument name="at_call" xsi:type="string">getDescription</argument>
-          <argument name="at_code" xsi:type="string">description</argument>
-          <argument name="css_class" xsi:type="string">description</argument>
-          <argument name="at_label" xsi:type="string">none</argument>
-          <argument name="title" translate="true" xsi:type="string">Details</argument>
-          <argument name="sort_order" xsi:type="string">10</argument>
-          <argument name="add_attribute" xsi:type="string">itemprop="description"</argument>
-      </arguments>
+    <arguments>
+        <argument name="at_call" xsi:type="string">getDescription</argument>
+        <argument name="at_code" xsi:type="string">description</argument>
+        <argument name="css_class" xsi:type="string">description</argument>
+        <argument name="at_label" xsi:type="string">none</argument>
+        <argument name="title" translate="true" xsi:type="string">Details</argument>
+        <argument name="sort_order" xsi:type="string">10</argument>
+        <argument name="add_attribute" xsi:type="string">itemprop="description"</argument>
+    </arguments>
 </block>
+```
 
+```html
 <!-- Example usage -->
 <div class="product attribute description">
   <div class="value" itemprop="description">
@@ -213,6 +217,7 @@ To add the `itemprop` attribute to another product attribute displayed in the `<
     </ul>
   </div>
 </div>
+```
 
 ```xml
 <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.overview" template="Magento_Catalog::product/view/attribute.phtml" group="detailed_info" after="product.info.extrahint">
@@ -229,9 +234,9 @@ To add the `itemprop` attribute to another product attribute displayed in the `<
 
 ```html
 <div class="product attribute overview">
-        <div class="value" itemprop="description">
-          <p>The instructors and routines featured in LifeLong Fitness IV provide safe options to serve all types of physical conditions and abilities. Range of motion, body awareness and breathing practices are essential tools of yogic self-care, essential for maintaining alertness, health, and dignity over a lifetime. The LifeLong Fitness series acknowledges that as we age, the safety and sustainability of our exercise become as important as pushing our limits.</p>
-        </div>
+    <div class="value" itemprop="description">
+        <p>The instructors and routines featured in LifeLong Fitness IV provide safe options to serve all types of physical conditions and abilities. Range of motion, body awareness and breathing practices are essential tools of yogic self-care, essential for maintaining alertness, health, and dignity over a lifetime. The LifeLong Fitness series acknowledges that as we age, the safety and sustainability of our exercise become as important as pushing our limits.</p>
+    </div>
 </div>
 ```
 
@@ -239,15 +244,15 @@ To generate `itemprop=description` for `description` attribute, move the `add_at
 
 ```xml
 <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.description" as="description" template="Magento_Catalog::product/view/attribute.phtml" group="detailed_info">
-      <arguments>
-          <argument name="at_call" xsi:type="string">getDescription</argument>
-          <argument name="at_code" xsi:type="string">description</argument>
-          <argument name="css_class" xsi:type="string">description</argument>
-          <argument name="at_label" xsi:type="string">none</argument>
-          <argument name="title" translate="true" xsi:type="string">Details</argument>
-          <argument name="sort_order" xsi:type="string">10</argument>
-          <argument name="add_attribute" xsi:type="string">itemprop="description"</argument>
-      </arguments>
+    <arguments>
+        <argument name="at_call" xsi:type="string">getDescription</argument>
+        <argument name="at_code" xsi:type="string">description</argument>
+        <argument name="css_class" xsi:type="string">description</argument>
+        <argument name="at_label" xsi:type="string">none</argument>
+        <argument name="title" translate="true" xsi:type="string">Details</argument>
+        <argument name="sort_order" xsi:type="string">10</argument>
+        <argument name="add_attribute" xsi:type="string">itemprop="description"</argument>
+    </arguments>
 </block>
 ```
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to fix the page's markup to improve its readability.
In the "Add or change itemprop global attribute for products" section, the XML and HTML code and examples markup was missing some "```".  This caused the "To add the `itemprop` attribute..." text to appear in the same block as the XML and HTML examples. 
This PR corrects the markup to separate the explanation text and code examples.

## Affected pages

- [Common customization tasks](https://developer.adobe.com/commerce/frontend-core/guide/layouts/xml-manage/#add-or-change-itemprop-global-attribute-for-products)
