### PR TITLE
Update the copyright in code samples

### DIFF
--- a/src/pages/guide/layouts/types.md
+++ b/src/pages/guide/layouts/types.md
@@ -102,8 +102,8 @@ Override the default `wishlist_index_share.xml` in any one of the following path
 <?xml version="1.0"?>
 <!--
 /**
- * Copyright &copy; Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All rights reserved.
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="3columns" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">

--- a/src/pages/guide/themes/create-admin.md
+++ b/src/pages/guide/themes/create-admin.md
@@ -55,8 +55,8 @@ In this file, add the following code, having replaced placeholders with your the
 ```php
 <?php
 /**
- * Copyright &copy; Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All rights reserved.
  */
 use \Magento\Framework\Component\ComponentRegistrar;
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'adminhtml/%vendor_dir/your_theme_dir%', __DIR__); // Example: 'adminhtml/Magento/backend'

--- a/src/pages/guide/themes/create-storefront.md
+++ b/src/pages/guide/themes/create-storefront.md
@@ -132,8 +132,8 @@ To register your theme in the system, add a `registration.php` file in your them
 ```php
 <?php
 /**
- * Copyright &copy; Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All rights reserved.
  */
 
 use \Magento\Framework\Component\ComponentRegistrar;

--- a/src/pages/page-builder/content-types/customize/index.md
+++ b/src/pages/page-builder/content-types/customize/index.md
@@ -54,7 +54,6 @@ Object content types, `xsi:type="object"`, must implement `ProviderInterface` in
 <?php
 /**
  * Copyright &copy; Adobe, Inc. All rights reserved.
- * See COPYING.txt for license details.
  */
 
 declare(strict_types=1);

--- a/src/pages/page-builder/migration/how-content-migration-works.md
+++ b/src/pages/page-builder/migration/how-content-migration-works.md
@@ -84,7 +84,6 @@ To learn more about renderers, let's look at the Heading renderer code, then dis
 ```php
 /**
  * Copyright &copy; Adobe, Inc. All rights reserved.
- * See COPYING.txt for license details.
  */
 declare(strict_types=1);
 

--- a/src/pages/page-builder/upgrade-content-types.md
+++ b/src/pages/page-builder/upgrade-content-types.md
@@ -41,7 +41,6 @@ Our converter class for fixing a row padding problem might be called `FixFullWid
 <?php
 /**
  * Copyright &copy; Adobe, Inc. All rights reserved.
- * See COPYING.txt for license details.
  */
 
 declare(strict_types=1);
@@ -108,7 +107,6 @@ For our Data Patch, we'll create a class called `UpgradeFullWidthPadding`, which
 <?php
 /**
  * Copyright &copy; Adobe, Inc. All rights reserved.
- * See COPYING.txt for license details.
  */
 namespace Magento\PageBuilder\Setup\Patch\Data;
 

--- a/src/pages/ui-components/components/url-input.md
+++ b/src/pages/ui-components/components/url-input.md
@@ -49,8 +49,8 @@ The option `class` implements `\Magento\Ui\Model\UrlInput\ConfigInterface` and p
 ```php
 <?php
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All Rights Reserved.
  */
 
 declare(strict_types=1);

--- a/src/pages/ui-components/components/wysiwyg/add-custom-editor.md
+++ b/src/pages/ui-components/components/wysiwyg/add-custom-editor.md
@@ -95,8 +95,8 @@ If you are integrating entities such as variable and widget as plugins, your ada
 
 ``` js
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All Rights Reserved.
  */
 
 /* global varienGlobalEvents, tinyMceEditors, MediabrowserUtility, closeEditorPopup, Base64 */

--- a/src/pages/ui-components/components/wysiwyg/extension-points.md
+++ b/src/pages/ui-components/components/wysiwyg/extension-points.md
@@ -109,8 +109,8 @@ init: function (ed) {
 
 ``` js
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All Rights Reserved.
  */
 
 /* global CKEDITOR, MagentovariablePlugin, varienGlobalEvents, Base64 */
@@ -234,8 +234,8 @@ init: function (ed, url) {
 
 ``` js
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All Rights Reserved.
  */
 
 /* global CKEDITOR, MagentovariablePlugin, varienGlobalEvents, Base64 */

--- a/src/pages/ui-components/components/wysiwyg/index.md
+++ b/src/pages/ui-components/components/wysiwyg/index.md
@@ -89,8 +89,8 @@ First, create a layout file in the `ModuleName\view\adminhtml\layout` directory 
 <?xml version="1.0"?>
 <!--
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All Rights Reserved.
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
@@ -110,8 +110,8 @@ Next, create a custom form in the `ModuleName\view\adminhtml\ui_component` direc
 <?xml version="1.0"?>
 <!--
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All Rights Reserved.
  */
 -->
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
@@ -168,8 +168,8 @@ To use PHP modifiers, your data provider must inherit from `ModifierPoolDataProv
 ```php
 <?php
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All Rights Reserved.
  */
 namespace Magento\Ui\DataProvider;
 
@@ -245,8 +245,8 @@ Your form must then use a data provider that inherits from `ModifierPoolDataProv
 ```php
 <?php
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All Rights Reserved.
  */
 namespace Test\Module\Model;
 
@@ -282,8 +282,8 @@ The following example shows how to change the default WYSIWYG editor toolbar and
 ```php
 <?php
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All Rights Reserved.
  */
 namespace Test\Module\Ui\DataProvider\Custom\Modifier;
 
@@ -334,8 +334,8 @@ Here's an example that connects the data provider and modifier created in the pr
 <?xml version="1.0"?>
 <!--
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All Rights Reserved.
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">

--- a/src/pages/ui-components/concepts/xml-declaration.md
+++ b/src/pages/ui-components/concepts/xml-declaration.md
@@ -47,8 +47,8 @@ The top node can have nested nodes. Every nested node is regarded as a separate 
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 /**
- * Copyright &copy; Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All rights reserved.
  */
 -->
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/pages/ui-components/howto/update-url-type.md
+++ b/src/pages/ui-components/howto/update-url-type.md
@@ -17,8 +17,8 @@ Create a `.php` file implementing the new link class in the module directory con
 ```php
 <?php
 /**
- * Copyright &copy; Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All rights reserved.
  */
 
 declare(strict_types=1);
@@ -93,8 +93,8 @@ Create the JavaScript implementation for the applicable UI component in your mod
 
 ```js
 /**
- * Copyright &copy; Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All rights reserved.
  */
 
 define([
@@ -195,8 +195,8 @@ Create a controller to search the page using a search key.
 ```php
 <?php
 /**
- * Copyright &copy; Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All rights reserved.
  */
 
 declare(strict_types=1);
@@ -277,8 +277,8 @@ Create a controller to return the page, or empty array if the option doesn't exi
 ```php
 <?php
 /**
- * Copyright &copy; Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright Adobe
+ * All rights reserved.
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the copyright in code samples.

## Affected pages

- https://developer.adobe.com/commerce/frontend-core/guide/layouts/types/
- https://developer.adobe.com/commerce/frontend-core/guide/themes/create-admin/
- https://developer.adobe.com/commerce/frontend-core/guide/themes/create-storefront/
- https://developer.adobe.com/commerce/frontend-core/page-builder/content-types/customize/
- https://developer.adobe.com/commerce/frontend-core/page-builder/migration/how-content-migration-works/
- https://developer.adobe.com/commerce/frontend-core/page-builder/upgrade-content-types/
- https://developer.adobe.com/commerce/frontend-core/ui-components/components/url-input/
- https://developer.adobe.com/commerce/frontend-core/ui-components/components/wysiwyg/add-custom-editor/
- https://developer.adobe.com/commerce/frontend-core/ui-components/components/wysiwyg/extension-points/
- https://developer.adobe.com/commerce/frontend-core/ui-components/components/wysiwyg/
- https://developer.adobe.com/commerce/frontend-core/ui-components/concepts/xml-declaration/
- https://developer.adobe.com/commerce/frontend-core/ui-components/howto/update-url-type/