### PR TITLE
Update information about Extending the TinyMCE editor in Adobe Commerce

### DIFF
--- a/src/pages/ui-components/components/wysiwyg/configure-tinymce-editor.md
+++ b/src/pages/ui-components/components/wysiwyg/configure-tinymce-editor.md
@@ -67,7 +67,9 @@ When extending the TinyMCE editor it is necessary to add the PageBuilder module 
 ```
 
 To customize the TinyMCE editor present in Page Builder, revise the `di.xml` file, adding the configuration settings as an argument to `Magento\PageBuilder\Model\Wysiwyg\DefaultConfigProvider`.
-The following code is an example of the configuration settings in the `di.xml` file that determine the font sizes available for selection. Then, it adds a paragraph menu option associated with the `<p>` tag:
+The following code is an example of the configuration settings in the `di.xml` file that determine the font sizes available for selection. It also adds a paragraph menu option associated with the <p> tag, along with a heading option for the <h1> tag.
+
+Note: Ensure numeric keys (0, 1, etc.) are used incrementally in the style_formats array instead of named keys like "paragraph" to maintain compatibility with the configuration:
 
 ```xml
 <type name="Magento\PageBuilder\Model\Wysiwyg\DefaultConfigProvider">
@@ -75,9 +77,13 @@ The following code is an example of the configuration settings in the `di.xml` f
         <argument name="additionalSettings" xsi:type="array">
             <item name="fontsize_formats" xsi:type="string">10px 12px 14px 16px 18px 20px 24px 26px 28px 32px 34px 36px 38px 40px 42px 48px 52px 56px 64px 72px</item>
             <item name="style_formats" xsi:type="array">
-                <item name="paragraph" xsi:type="array">
+                <item name="0" xsi:type="array">
                     <item name="title" xsi:type="string">Paragraph</item>
                     <item name="block" xsi:type="string">p</item>
+                </item>
+                <item name="1" xsi:type="array">
+                    <item name="title" xsi:type="string">Heading 1</item>
+                    <item name="block" xsi:type="string">h1</item>
                 </item>
             </item>
       </argument>


### PR DESCRIPTION
## Purpose of this pull request
This pull request (PR) provides instructions for updating the Extending the TinyMCE editor in Adobe Commerce, as the current documentation is not working. 

This PR addresses the issue mentioned in ticket [[AC-9200](https://jira.corp.adobe.com/browse/AC-9200)](https://jira.corp.adobe.com/browse/AC-9200), where the instructions in the Adobe Commerce developer document were found to be incorrect. Based on the discussions in the ticket, this update revises the documentation accordingly. Once the document is updated, the issue outlined in the ticket will be resolved.

This pull request (PR) ...

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-frontend-core/blob/main/.github/CONTRIBUTING.md) for more information.
-->
